### PR TITLE
generated files after running gradle task extractJarFile

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -57,6 +57,8 @@ dependencies {
   runtime "com.avast.gradle:gradle-docker-compose-plugin:0.8.8"                                       // Enable docker compose tasks
   runtime "ca.cutterslade.gradle:gradle-dependency-analyze:1.3.1"                                     // Enable dep analysis
   runtime "gradle.plugin.net.ossindex:ossindex-gradle-plugin:0.4.11"                                  // Enable dep vulnerability analysis
+
+  implementation 'org.apache.beam:beam-sdks-java-maven-archetypes-examples:2.21.0'
 }
 
 // Because buildSrc is built and tested automatically _before_ gradle
@@ -94,4 +96,16 @@ gradlePlugin {
       implementationClass = 'org.apache.beam.gradle.BeamJenkinsPlugin'
     }
   }
+}
+
+task copyJarFiles(type: Copy) {
+  from configurations.compileClasspath
+  into "$buildDir/lib"
+}
+
+task extractJarFile(dependsOn: copyJarFiles, type: Copy) {
+  from(zipTree("$buildDir/lib/beam-sdks-java-maven-archetypes-examples-2.21.0.jar")) {
+    include "archetype-resources/"
+  }
+  into "src"
 }

--- a/buildSrc/src/archetype-resources/pom.xml
+++ b/buildSrc/src/archetype-resources/pom.xml
@@ -1,0 +1,509 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>${groupId}</groupId>
+  <artifactId>${artifactId}</artifactId>
+  <version>${version}</version>
+
+  <packaging>jar</packaging>
+
+  <properties>
+    <beam.version>2.21.0</beam.version>
+
+    <bigquery.version>v2-rev20191211-1.30.3</bigquery.version>
+    <google-api-client.version>1.30.3</google-api-client.version>
+    <google-http-client.version>1.34.0</google-http-client.version>
+    <hamcrest.version>2.1</hamcrest.version>
+    <jackson.version>2.10.2</jackson.version>
+    <joda.version>2.10.5</joda.version>
+    <junit.version>4.13-beta-3</junit.version>
+    <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
+    <maven-exec-plugin.version>1.6.0</maven-exec-plugin.version>
+    <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
+    <maven-shade-plugin.version>3.1.0</maven-shade-plugin.version>
+    <mockito.version>3.0.0</mockito.version>
+    <pubsub.version>v1-rev20191111-1.30.3</pubsub.version>
+    <slf4j.version>1.7.25</slf4j.version>
+    <spark.version>2.4.5</spark.version>
+    <hadoop.version>2.8.5</hadoop.version>
+    <maven-surefire-plugin.version>2.21.0</maven-surefire-plugin.version>
+    <nemo.version>0.1</nemo.version>
+    <flink.artifact.name>beam-runners-flink-1.10</flink.artifact.name>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>apache.snapshots</id>
+      <name>Apache Development Snapshot Repository</name>
+      <url>https://repository.apache.org/content/repositories/snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
+        <configuration>
+          <source>${targetPlatform}</source>
+          <target>${targetPlatform}</target>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven-surefire-plugin.version}</version>
+        <configuration>
+          <parallel>all</parallel>
+          <threadCount>4</threadCount>
+          <redirectTestOutputToFile>true</redirectTestOutputToFile>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit47</artifactId>
+            <version>${maven-surefire-plugin.version}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+
+      <!-- Ensure that the Maven jar plugin runs before the Maven
+        shade plugin by listing the plugin higher within the file. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${maven-jar-plugin.version}</version>
+      </plugin>
+
+      <!--
+        Configures `mvn package` to produce a bundled jar ("fat jar") for runners
+        that require this for job submission to a cluster.
+      -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>${maven-shade-plugin.version}</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <finalName>${project.artifactId}-bundled-${project.version}</finalName>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/LICENSE</exclude>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>${maven-exec-plugin.version}</version>
+          <configuration>
+            <cleanupDaemonThreads>false</cleanupDaemonThreads>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>direct-runner</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <!-- Makes the DirectRunner available when running a pipeline. -->
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.beam</groupId>
+          <artifactId>beam-runners-direct-java</artifactId>
+          <version>${beam.version}</version>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+
+   <profile>
+      <id>portable-runner</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <!-- Makes the PortableRunner available when running a pipeline. -->
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.beam</groupId>
+          <artifactId>beam-runners-portability-java</artifactId>
+          <version>${beam.version}</version>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>apex-runner</id>
+      <!-- Makes the ApexRunner available when running a pipeline. -->
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.beam</groupId>
+          <artifactId>beam-runners-apex</artifactId>
+          <version>${beam.version}</version>
+          <scope>runtime</scope>
+        </dependency>
+        <!--
+          Apex depends on httpclient version 4.3.6, project has a transitive dependency to httpclient 4.0.1 from
+          google-http-client. Apex dependency version being specified explicitly so that it gets picked up. This
+          can be removed when the project no longer has a dependency on a different httpclient version.
+        -->
+        <dependency>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+          <version>4.3.6</version>
+          <scope>runtime</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>commons-codec</groupId>
+              <artifactId>commons-codec</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+        <!--
+          Apex 3.6 is built against YARN 2.6. Version in the fat jar has to match
+          what's on the cluster, hence we need to repeat the Apex Hadoop dependencies here.
+        -->
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-yarn-client</artifactId>
+          <version>${hadoop.version}</version>
+          <scope>runtime</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-common</artifactId>
+          <version>${hadoop.version}</version>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>dataflow-runner</id>
+      <!-- Makes the DataflowRunner available when running a pipeline. -->
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.beam</groupId>
+          <artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
+          <version>${beam.version}</version>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>flink-runner</id>
+      <!-- Makes the FlinkRunner available when running a pipeline. -->
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.beam</groupId>
+          <!-- Please see the Flink Runner page for an up-to-date list
+               of supported Flink versions and their artifact names:
+               https://beam.apache.org/documentation/runners/flink/ -->
+          <artifactId>${flink.artifact.name}</artifactId>
+          <version>${beam.version}</version>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>spark-runner</id>
+      <!-- Makes the SparkRunner available when running a pipeline. Additionally,
+           overrides some Spark dependencies to Beam-compatible versions. -->
+      <properties>
+        <netty.version>4.1.17.Final</netty.version>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.beam</groupId>
+          <artifactId>beam-runners-spark</artifactId>
+          <version>${beam.version}</version>
+          <scope>runtime</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.beam</groupId>
+          <artifactId>beam-sdks-java-io-hadoop-file-system</artifactId>
+          <version>${beam.version}</version>
+          <scope>runtime</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-streaming_2.11</artifactId>
+          <version>${spark.version}</version>
+          <scope>runtime</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>org.slf4j</groupId>
+              <artifactId>jul-to-slf4j</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+        <dependency>
+          <groupId>com.fasterxml.jackson.module</groupId>
+          <artifactId>jackson-module-scala_2.11</artifactId>
+          <version>${jackson.version}</version>
+          <scope>runtime</scope>
+        </dependency>
+        <!-- [BEAM-3519] GCP IO exposes netty on its API surface, causing conflicts with runners -->
+        <dependency>
+          <groupId>org.apache.beam</groupId>
+          <artifactId>beam-sdks-java-io-google-cloud-platform</artifactId>
+          <version>${beam.version}</version>
+          <exclusions>
+            <exclusion>
+              <groupId>io.grpc</groupId>
+              <artifactId>grpc-netty</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>io.netty</groupId>
+              <artifactId>netty-handler</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>gearpump-runner</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.beam</groupId>
+          <artifactId>beam-runners-gearpump</artifactId>
+          <version>${beam.version}</version>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>samza-runner</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.beam</groupId>
+          <artifactId>beam-runners-samza</artifactId>
+          <version>${beam.version}</version>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>nemo-runner</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.nemo</groupId>
+          <artifactId>nemo-compiler-frontend-beam</artifactId>
+          <version>${nemo.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-common</artifactId>
+          <version>${hadoop.version}</version>
+          <exclusions>
+            <exclusion>
+              <groupId>org.slf4j</groupId>
+              <artifactId>slf4j-api</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>org.slf4j</groupId>
+              <artifactId>slf4j-log4j12</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>jet-runner</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.beam</groupId>
+          <artifactId>beam-runners-jet</artifactId>
+          <version>${beam.version}</version>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+
+  </profiles>
+
+  <dependencies>
+    <!-- Adds a dependency on the Beam SDK. -->
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-sdks-java-core</artifactId>
+      <version>${beam.version}</version>
+    </dependency>
+
+    <!-- Adds a dependency on the Beam Google Cloud Platform IO module. -->
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-sdks-java-io-google-cloud-platform</artifactId>
+      <version>${beam.version}</version>
+    </dependency>
+
+    <!-- Dependencies below this line are specific dependencies needed by the examples code. -->
+    <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client</artifactId>
+      <version>${google-api-client.version}</version>
+      <exclusions>
+        <!-- Exclude an old version of guava that is being pulled
+             in by a transitive dependency of google-api-client -->
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava-jdk5</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-bigquery</artifactId>
+      <version>${bigquery.version}</version>
+      <exclusions>
+        <!-- Exclude an old version of guava that is being pulled
+             in by a transitive dependency of google-api-client -->
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava-jdk5</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client</artifactId>
+      <version>${google-http-client.version}</version>
+      <exclusions>
+        <!-- Exclude an old version of guava that is being pulled
+             in by a transitive dependency of google-api-client -->
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava-jdk5</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-pubsub</artifactId>
+      <version>${pubsub.version}</version>
+      <exclusions>
+        <!-- Exclude an old version of guava that is being pulled
+             in by a transitive dependency of google-api-client -->
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava-jdk5</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+      <version>${joda.version}</version>
+    </dependency>
+
+    <!-- Add slf4j API frontend binding with JUL backend -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+      <version>${slf4j.version}</version>
+      <!-- When loaded at runtime this will wire up slf4j to the JUL backend -->
+      <scope>runtime</scope>
+    </dependency>
+
+    <!-- Hamcrest and JUnit are required dependencies of PAssert,
+         which is used in the main code of DebuggingWordCount example. -->
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>${hamcrest.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <version>${hamcrest.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+    </dependency>
+
+    <!-- The DirectRunner is needed for unit tests. -->
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-runners-direct-java</artifactId>
+      <version>${beam.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/buildSrc/src/archetype-resources/src/main/java/DebuggingWordCount.java
+++ b/buildSrc/src/archetype-resources/src/main/java/DebuggingWordCount.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package};
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.io.TextIO;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Metrics;
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An example that verifies word counts in Shakespeare and includes Beam best practices.
+ *
+ * <p>This class, {@link DebuggingWordCount}, is the third in a series of four successively more
+ * detailed 'word count' examples. You may first want to take a look at {@link MinimalWordCount} and
+ * {@link WordCount}. After you've looked at this example, then see the {@link WindowedWordCount}
+ * pipeline, for introduction of additional concepts.
+ *
+ * <p>Basic concepts, also in the MinimalWordCount and WordCount examples: Reading text files;
+ * counting a PCollection; executing a Pipeline both locally and using a selected runner; defining
+ * DoFns.
+ *
+ * <p>New Concepts:
+ *
+ * <pre>
+ *   1. Logging using SLF4J, even in a distributed environment
+ *   2. Creating a custom metric (runners have varying levels of support)
+ *   3. Testing your Pipeline via PAssert
+ * </pre>
+ *
+ * <p>To execute this pipeline locally, specify general pipeline configuration:
+ *
+ * <pre>{@code
+ * --project=YOUR_PROJECT_ID
+ * }</pre>
+ *
+ * <p>To change the runner, specify:
+ *
+ * <pre>{@code
+ * --runner=YOUR_SELECTED_RUNNER
+ * }</pre>
+ *
+ * <p>The input file defaults to a public data set containing the text of of King Lear, by William
+ * Shakespeare. You can override it and choose your own input with {@code --inputFile}.
+ */
+public class DebuggingWordCount {
+  /** A DoFn that filters for a specific key based upon a regular expression. */
+  public static class FilterTextFn extends DoFn<KV<String, Long>, KV<String, Long>> {
+    /**
+     * Concept #1: The logger below uses the fully qualified class name of FilterTextFn as the
+     * logger. Depending on your SLF4J configuration, log statements will likely be qualified by
+     * this name.
+     *
+     * <p>Note that this is entirely standard SLF4J usage. Some runners may provide a default SLF4J
+     * configuration that is most appropriate for their logging integration.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(FilterTextFn.class);
+
+    private final Pattern filter;
+
+    public FilterTextFn(String pattern) {
+      filter = Pattern.compile(pattern);
+    }
+
+    /**
+     * Concept #2: A custom metric can track values in your pipeline as it runs. Each runner
+     * provides varying levels of support for metrics, and may expose them in a dashboard, etc.
+     */
+    private final Counter matchedWords = Metrics.counter(FilterTextFn.class, "matchedWords");
+
+    private final Counter unmatchedWords = Metrics.counter(FilterTextFn.class, "unmatchedWords");
+
+    @ProcessElement
+    public void processElement(ProcessContext c) {
+      if (filter.matcher(c.element().getKey()).matches()) {
+        // Log at the "DEBUG" level each element that we match. When executing this pipeline
+        // these log lines will appear only if the log level is set to "DEBUG" or lower.
+        LOG.debug("Matched: " + c.element().getKey());
+        matchedWords.inc();
+        c.output(c.element());
+      } else {
+        // Log at the "TRACE" level each element that is not matched. Different log levels
+        // can be used to control the verbosity of logging providing an effective mechanism
+        // to filter less important information.
+        LOG.trace("Did not match: " + c.element().getKey());
+        unmatchedWords.inc();
+      }
+    }
+  }
+
+  /**
+   * Options supported by {@link DebuggingWordCount}.
+   *
+   * <p>Inherits standard configuration options and all options defined in {@link
+   * WordCount.WordCountOptions}.
+   */
+  public interface WordCountOptions extends WordCount.WordCountOptions {
+
+    @Description(
+        "Regex filter pattern to use in DebuggingWordCount. "
+            + "Only words matching this pattern will be counted.")
+    @Default.String("Flourish|stomach")
+    String getFilterPattern();
+
+    void setFilterPattern(String value);
+  }
+
+  static void runDebuggingWordCount(WordCountOptions options) {
+    Pipeline p = Pipeline.create(options);
+
+    PCollection<KV<String, Long>> filteredWords =
+        p.apply("ReadLines", TextIO.read().from(options.getInputFile()))
+            .apply(new WordCount.CountWords())
+            .apply(ParDo.of(new FilterTextFn(options.getFilterPattern())));
+
+    /*
+     * Concept #3: PAssert is a set of convenient PTransforms in the style of
+     * Hamcrest's collection matchers that can be used when writing Pipeline level tests
+     * to validate the contents of PCollections. PAssert is best used in unit tests
+     * with small data sets but is demonstrated here as a teaching tool.
+     *
+     * <p>Below we verify that the set of filtered words matches our expected counts. Note
+     * that PAssert does not provide any output and that successful completion of the
+     * Pipeline implies that the expectations were met. Learn more at
+     * https://beam.apache.org/documentation/pipelines/test-your-pipeline/ on how to test
+     * your Pipeline and see {@link DebuggingWordCountTest} for an example unit test.
+     */
+    List<KV<String, Long>> expectedResults =
+        Arrays.asList(KV.of("Flourish", 3L), KV.of("stomach", 1L));
+    PAssert.that(filteredWords).containsInAnyOrder(expectedResults);
+
+    p.run().waitUntilFinish();
+  }
+
+  public static void main(String[] args) {
+    WordCountOptions options =
+        PipelineOptionsFactory.fromArgs(args).withValidation().as(WordCountOptions.class);
+
+    runDebuggingWordCount(options);
+  }
+}

--- a/buildSrc/src/archetype-resources/src/main/java/MinimalWordCount.java
+++ b/buildSrc/src/archetype-resources/src/main/java/MinimalWordCount.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package};
+
+import java.util.Arrays;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.io.TextIO;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.transforms.Count;
+import org.apache.beam.sdk.transforms.Filter;
+import org.apache.beam.sdk.transforms.FlatMapElements;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.TypeDescriptors;
+
+/**
+ * An example that counts words in Shakespeare.
+ *
+ * <p>This class, {@link MinimalWordCount}, is the first in a series of four successively more
+ * detailed 'word count' examples. Here, for simplicity, we don't show any error-checking or
+ * argument processing, and focus on construction of the pipeline, which chains together the
+ * application of core transforms.
+ *
+ * <p>Next, see the {@link WordCount} pipeline, then the {@link DebuggingWordCount}, and finally the
+ * {@link WindowedWordCount} pipeline, for more detailed examples that introduce additional
+ * concepts.
+ *
+ * <p>Concepts:
+ *
+ * <pre>
+ *   1. Reading data from text files
+ *   2. Specifying 'inline' transforms
+ *   3. Counting items in a PCollection
+ *   4. Writing data to text files
+ * </pre>
+ *
+ * <p>No arguments are required to run this pipeline. It will be executed with the DirectRunner. You
+ * can see the results in the output files in your current working directory, with names like
+ * "wordcounts-00001-of-00005. When running on a distributed service, you would use an appropriate
+ * file service.
+ */
+public class MinimalWordCount {
+
+  public static void main(String[] args) {
+
+    // Create a PipelineOptions object. This object lets us set various execution
+    // options for our pipeline, such as the runner you wish to use. This example
+    // will run with the DirectRunner by default, based on the class path configured
+    // in its dependencies.
+    PipelineOptions options = PipelineOptionsFactory.create();
+
+    // In order to run your pipeline, you need to make following runner specific changes:
+    //
+    // CHANGE 1/3: Select a Beam runner, such as BlockingDataflowRunner
+    // or FlinkRunner.
+    // CHANGE 2/3: Specify runner-required options.
+    // For BlockingDataflowRunner, set project and temp location as follows:
+    //   DataflowPipelineOptions dataflowOptions = options.as(DataflowPipelineOptions.class);
+    //   dataflowOptions.setRunner(BlockingDataflowRunner.class);
+    //   dataflowOptions.setProject("SET_YOUR_PROJECT_ID_HERE");
+    //   dataflowOptions.setTempLocation("gs://SET_YOUR_BUCKET_NAME_HERE/AND_TEMP_DIRECTORY");
+    // For FlinkRunner, set the runner as follows. See {@code FlinkPipelineOptions}
+    // for more details.
+    //   options.as(FlinkPipelineOptions.class)
+    //      .setRunner(FlinkRunner.class);
+
+    // Create the Pipeline object with the options we defined above
+    Pipeline p = Pipeline.create(options);
+
+    // Concept #1: Apply a root transform to the pipeline; in this case, TextIO.Read to read a set
+    // of input text files. TextIO.Read returns a PCollection where each element is one line from
+    // the input text (a set of Shakespeare's texts).
+
+    // This example reads a public data set consisting of the complete works of Shakespeare.
+    p.apply(TextIO.read().from("gs://apache-beam-samples/shakespeare/*"))
+
+        // Concept #2: Apply a FlatMapElements transform the PCollection of text lines.
+        // This transform splits the lines in PCollection<String>, where each element is an
+        // individual word in Shakespeare's collected texts.
+        .apply(
+            FlatMapElements.into(TypeDescriptors.strings())
+                .via((String line) -> Arrays.asList(line.split("[^\\p{L}]+"))))
+        // We use a Filter transform to avoid empty word
+        .apply(Filter.by((String word) -> !word.isEmpty()))
+        // Concept #3: Apply the Count transform to our PCollection of individual words. The Count
+        // transform returns a new PCollection of key/value pairs, where each key represents a
+        // unique word in the text. The associated value is the occurrence count for that word.
+        .apply(Count.perElement())
+        // Apply a MapElements transform that formats our PCollection of word counts into a
+        // printable string, suitable for writing to an output file.
+        .apply(
+            MapElements.into(TypeDescriptors.strings())
+                .via(
+                    (KV<String, Long> wordCount) ->
+                        wordCount.getKey() + ": " + wordCount.getValue()))
+        // Concept #4: Apply a write transform, TextIO.Write, at the end of the pipeline.
+        // TextIO.Write writes the contents of a PCollection (in this case, our PCollection of
+        // formatted strings) to a series of text files.
+        //
+        // By default, it will write to a set of files with names like wordcounts-00001-of-00005
+        .apply(TextIO.write().to("wordcounts"));
+
+    p.run().waitUntilFinish();
+  }
+}

--- a/buildSrc/src/archetype-resources/src/main/java/WindowedWordCount.java
+++ b/buildSrc/src/archetype-resources/src/main/java/WindowedWordCount.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package};
+
+import java.io.IOException;
+import java.util.concurrent.ThreadLocalRandom;
+import ${package}.common.ExampleBigQueryTableOptions;
+import ${package}.common.ExampleOptions;
+import ${package}.common.WriteOneFilePerWindow;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.io.TextIO;
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.DefaultValueFactory;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.windowing.FixedWindows;
+import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+
+/**
+ * An example that counts words in text, and can run over either unbounded or bounded input
+ * collections.
+ *
+ * <p>This class, {@link WindowedWordCount}, is the last in a series of four successively more
+ * detailed 'word count' examples. First take a look at {@link MinimalWordCount}, {@link WordCount},
+ * and {@link DebuggingWordCount}.
+ *
+ * <p>Basic concepts, also in the MinimalWordCount, WordCount, and DebuggingWordCount examples:
+ * Reading text files; counting a PCollection; writing to GCS; executing a Pipeline both locally and
+ * using a selected runner; defining DoFns; user-defined PTransforms; defining PipelineOptions.
+ *
+ * <p>New Concepts:
+ *
+ * <pre>
+ *   1. Unbounded and bounded pipeline input modes
+ *   2. Adding timestamps to data
+ *   3. Windowing
+ *   4. Re-using PTransforms over windowed PCollections
+ *   5. Accessing the window of an element
+ *   6. Writing data to per-window text files
+ * </pre>
+ *
+ * <p>By default, the examples will run with the {@code DirectRunner}. To change the runner,
+ * specify:
+ *
+ * <pre>{@code
+ * --runner=YOUR_SELECTED_RUNNER
+ * }</pre>
+ *
+ * See examples/java/README.md for instructions about how to configure different runners.
+ *
+ * <p>To execute this pipeline locally, specify a local output file (if using the {@code
+ * DirectRunner}) or output prefix on a supported distributed file system.
+ *
+ * <pre>{@code
+ * --output=[YOUR_LOCAL_FILE | YOUR_OUTPUT_PREFIX]
+ * }</pre>
+ *
+ * <p>The input file defaults to a public data set containing the text of of King Lear, by William
+ * Shakespeare. You can override it and choose your own input with {@code --inputFile}.
+ *
+ * <p>By default, the pipeline will do fixed windowing, on 10-minute windows. You can change this
+ * interval by setting the {@code --windowSize} parameter, e.g. {@code --windowSize=15} for
+ * 15-minute windows.
+ *
+ * <p>The example will try to cancel the pipeline on the signal to terminate the process (CTRL-C).
+ */
+public class WindowedWordCount {
+  static final int WINDOW_SIZE = 10; // Default window duration in minutes
+  /**
+   * Concept #2: A DoFn that sets the data element timestamp. This is a silly method, just for this
+   * example, for the bounded data case.
+   *
+   * <p>Imagine that many ghosts of Shakespeare are all typing madly at the same time to recreate
+   * his masterworks. Each line of the corpus will get a random associated timestamp somewhere in a
+   * 2-hour period.
+   */
+  static class AddTimestampFn extends DoFn<String, String> {
+    private final Instant minTimestamp;
+    private final Instant maxTimestamp;
+
+    AddTimestampFn(Instant minTimestamp, Instant maxTimestamp) {
+      this.minTimestamp = minTimestamp;
+      this.maxTimestamp = maxTimestamp;
+    }
+
+    @ProcessElement
+    public void processElement(@Element String element, OutputReceiver<String> receiver) {
+      Instant randomTimestamp =
+          new Instant(
+              ThreadLocalRandom.current()
+                  .nextLong(minTimestamp.getMillis(), maxTimestamp.getMillis()));
+
+      /*
+       * Concept #2: Set the data element with that timestamp.
+       */
+      receiver.outputWithTimestamp(element, randomTimestamp);
+    }
+  }
+
+  /** A {@link DefaultValueFactory} that returns the current system time. */
+  public static class DefaultToCurrentSystemTime implements DefaultValueFactory<Long> {
+    @Override
+    public Long create(PipelineOptions options) {
+      return System.currentTimeMillis();
+    }
+  }
+
+  /** A {@link DefaultValueFactory} that returns the minimum timestamp plus one hour. */
+  public static class DefaultToMinTimestampPlusOneHour implements DefaultValueFactory<Long> {
+    @Override
+    public Long create(PipelineOptions options) {
+      return options.as(Options.class).getMinTimestampMillis()
+          + Duration.standardHours(1).getMillis();
+    }
+  }
+
+  /**
+   * Options for {@link WindowedWordCount}.
+   *
+   * <p>Inherits standard example configuration options, which allow specification of the runner, as
+   * well as the {@link WordCount.WordCountOptions} support for specification of the input and
+   * output files.
+   */
+  public interface Options
+      extends WordCount.WordCountOptions, ExampleOptions, ExampleBigQueryTableOptions {
+    @Description("Fixed window duration, in minutes")
+    @Default.Integer(WINDOW_SIZE)
+    Integer getWindowSize();
+
+    void setWindowSize(Integer value);
+
+    @Description("Minimum randomly assigned timestamp, in milliseconds-since-epoch")
+    @Default.InstanceFactory(DefaultToCurrentSystemTime.class)
+    Long getMinTimestampMillis();
+
+    void setMinTimestampMillis(Long value);
+
+    @Description("Maximum randomly assigned timestamp, in milliseconds-since-epoch")
+    @Default.InstanceFactory(DefaultToMinTimestampPlusOneHour.class)
+    Long getMaxTimestampMillis();
+
+    void setMaxTimestampMillis(Long value);
+
+    @Description("Fixed number of shards to produce per window")
+    Integer getNumShards();
+
+    void setNumShards(Integer numShards);
+  }
+
+  static void runWindowedWordCount(Options options) throws IOException {
+    final String output = options.getOutput();
+    final Instant minTimestamp = new Instant(options.getMinTimestampMillis());
+    final Instant maxTimestamp = new Instant(options.getMaxTimestampMillis());
+
+    Pipeline pipeline = Pipeline.create(options);
+
+    /*
+     * Concept #1: the Beam SDK lets us run the same pipeline with either a bounded or
+     * unbounded input source.
+     */
+    PCollection<String> input =
+        pipeline
+            /* Read from the GCS file. */
+            .apply(TextIO.read().from(options.getInputFile()))
+            // Concept #2: Add an element timestamp, using an artificial time just to show
+            // windowing.
+            // See AddTimestampFn for more detail on this.
+            .apply(ParDo.of(new AddTimestampFn(minTimestamp, maxTimestamp)));
+
+    /*
+     * Concept #3: Window into fixed windows. The fixed window size for this example defaults to 1
+     * minute (you can change this with a command-line option). See the documentation for more
+     * information on how fixed windows work, and for information on the other types of windowing
+     * available (e.g., sliding windows).
+     */
+    PCollection<String> windowedWords =
+        input.apply(
+            Window.into(FixedWindows.of(Duration.standardMinutes(options.getWindowSize()))));
+
+    /*
+     * Concept #4: Re-use our existing CountWords transform that does not have knowledge of
+     * windows over a PCollection containing windowed values.
+     */
+    PCollection<KV<String, Long>> wordCounts = windowedWords.apply(new WordCount.CountWords());
+
+    /*
+     * Concept #5: Format the results and write to a sharded file partitioned by window, using a
+     * simple ParDo operation. Because there may be failures followed by retries, the
+     * writes must be idempotent, but the details of writing to files is elided here.
+     */
+    wordCounts
+        .apply(MapElements.via(new WordCount.FormatAsTextFn()))
+        .apply(new WriteOneFilePerWindow(output, options.getNumShards()));
+
+    PipelineResult result = pipeline.run();
+    try {
+      result.waitUntilFinish();
+    } catch (Exception exc) {
+      result.cancel();
+    }
+  }
+
+  public static void main(String[] args) throws IOException {
+    Options options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
+
+    runWindowedWordCount(options);
+  }
+}

--- a/buildSrc/src/archetype-resources/src/main/java/WordCount.java
+++ b/buildSrc/src/archetype-resources/src/main/java/WordCount.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package};
+
+import ${package}.common.ExampleUtils;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.io.TextIO;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Distribution;
+import org.apache.beam.sdk.metrics.Metrics;
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.Validation.Required;
+import org.apache.beam.sdk.transforms.Count;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.SimpleFunction;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+
+/**
+ * An example that counts words in Shakespeare and includes Beam best practices.
+ *
+ * <p>This class, {@link WordCount}, is the second in a series of four successively more detailed
+ * 'word count' examples. You may first want to take a look at {@link MinimalWordCount}. After
+ * you've looked at this example, then see the {@link DebuggingWordCount} pipeline, for introduction
+ * of additional concepts.
+ *
+ * <p>For a detailed walkthrough of this example, see <a
+ * href="https://beam.apache.org/get-started/wordcount-example/">
+ * https://beam.apache.org/get-started/wordcount-example/ </a>
+ *
+ * <p>Basic concepts, also in the MinimalWordCount example: Reading text files; counting a
+ * PCollection; writing to text files
+ *
+ * <p>New Concepts:
+ *
+ * <pre>
+ *   1. Executing a Pipeline both locally and using the selected runner
+ *   2. Using ParDo with static DoFns defined out-of-line
+ *   3. Building a composite transform
+ *   4. Defining your own pipeline options
+ * </pre>
+ *
+ * <p>Concept #1: you can execute this pipeline either locally or using by selecting another runner.
+ * These are now command-line options and not hard-coded as they were in the MinimalWordCount
+ * example.
+ *
+ * <p>To change the runner, specify:
+ *
+ * <pre>{@code
+ * --runner=YOUR_SELECTED_RUNNER
+ * }</pre>
+ *
+ * <p>To execute this pipeline, specify a local output file (if using the {@code DirectRunner}) or
+ * output prefix on a supported distributed file system.
+ *
+ * <pre>{@code
+ * --output=[YOUR_LOCAL_FILE | YOUR_OUTPUT_PREFIX]
+ * }</pre>
+ *
+ * <p>The input file defaults to a public data set containing the text of of King Lear, by William
+ * Shakespeare. You can override it and choose your own input with {@code --inputFile}.
+ */
+public class WordCount {
+
+  /**
+   * Concept #2: You can make your pipeline assembly code less verbose by defining your DoFns
+   * statically out-of-line. This DoFn tokenizes lines of text into individual words; we pass it to
+   * a ParDo in the pipeline.
+   */
+  static class ExtractWordsFn extends DoFn<String, String> {
+    private final Counter emptyLines = Metrics.counter(ExtractWordsFn.class, "emptyLines");
+    private final Distribution lineLenDist =
+        Metrics.distribution(ExtractWordsFn.class, "lineLenDistro");
+
+    @ProcessElement
+    public void processElement(@Element String element, OutputReceiver<String> receiver) {
+      lineLenDist.update(element.length());
+      if (element.trim().isEmpty()) {
+        emptyLines.inc();
+      }
+
+      // Split the line into words.
+      String[] words = element.split(ExampleUtils.TOKENIZER_PATTERN, -1);
+
+      // Output each word encountered into the output PCollection.
+      for (String word : words) {
+        if (!word.isEmpty()) {
+          receiver.output(word);
+        }
+      }
+    }
+  }
+
+  /** A SimpleFunction that converts a Word and Count into a printable string. */
+  public static class FormatAsTextFn extends SimpleFunction<KV<String, Long>, String> {
+    @Override
+    public String apply(KV<String, Long> input) {
+      return input.getKey() + ": " + input.getValue();
+    }
+  }
+
+  /**
+   * A PTransform that converts a PCollection containing lines of text into a PCollection of
+   * formatted word counts.
+   *
+   * <p>Concept #3: This is a custom composite transform that bundles two transforms (ParDo and
+   * Count) as a reusable PTransform subclass. Using composite transforms allows for easy reuse,
+   * modular testing, and an improved monitoring experience.
+   */
+  public static class CountWords
+      extends PTransform<PCollection<String>, PCollection<KV<String, Long>>> {
+    @Override
+    public PCollection<KV<String, Long>> expand(PCollection<String> lines) {
+
+      // Convert lines of text into individual words.
+      PCollection<String> words = lines.apply(ParDo.of(new ExtractWordsFn()));
+
+      // Count the number of times each word occurs.
+      PCollection<KV<String, Long>> wordCounts = words.apply(Count.perElement());
+
+      return wordCounts;
+    }
+  }
+
+  /**
+   * Options supported by {@link WordCount}.
+   *
+   * <p>Concept #4: Defining your own configuration options. Here, you can add your own arguments to
+   * be processed by the command-line parser, and specify default values for them. You can then
+   * access the options values in your pipeline code.
+   *
+   * <p>Inherits standard configuration options.
+   */
+  public interface WordCountOptions extends PipelineOptions {
+
+    /**
+     * By default, this example reads from a public dataset containing the text of King Lear. Set
+     * this option to choose a different input file or glob.
+     */
+    @Description("Path of the file to read from")
+    @Default.String("gs://apache-beam-samples/shakespeare/kinglear.txt")
+    String getInputFile();
+
+    void setInputFile(String value);
+
+    /** Set this required option to specify where to write the output. */
+    @Description("Path of the file to write to")
+    @Required
+    String getOutput();
+
+    void setOutput(String value);
+  }
+
+  static void runWordCount(WordCountOptions options) {
+    Pipeline p = Pipeline.create(options);
+
+    // Concepts #2 and #3: Our pipeline applies the composite CountWords transform, and passes the
+    // static FormatAsTextFn() to the ParDo transform.
+    p.apply("ReadLines", TextIO.read().from(options.getInputFile()))
+        .apply(new CountWords())
+        .apply(MapElements.via(new FormatAsTextFn()))
+        .apply("WriteCounts", TextIO.write().to(options.getOutput()));
+
+    p.run().waitUntilFinish();
+  }
+
+  public static void main(String[] args) {
+    WordCountOptions options =
+        PipelineOptionsFactory.fromArgs(args).withValidation().as(WordCountOptions.class);
+
+    runWordCount(options);
+  }
+}

--- a/buildSrc/src/archetype-resources/src/main/java/common/ExampleBigQueryTableOptions.java
+++ b/buildSrc/src/archetype-resources/src/main/java/common/ExampleBigQueryTableOptions.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.common;
+
+import com.google.api.services.bigquery.model.TableSchema;
+import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.DefaultValueFactory;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptions;
+
+/**
+ * Options that can be used to configure BigQuery tables in Beam examples. The project defaults to
+ * the project being used to run the example.
+ */
+public interface ExampleBigQueryTableOptions extends GcpOptions {
+  @Description("BigQuery dataset name")
+  @Default.String("beam_examples")
+  String getBigQueryDataset();
+
+  void setBigQueryDataset(String dataset);
+
+  @Description("BigQuery table name")
+  @Default.InstanceFactory(BigQueryTableFactory.class)
+  String getBigQueryTable();
+
+  void setBigQueryTable(String table);
+
+  @Description("BigQuery table schema")
+  TableSchema getBigQuerySchema();
+
+  void setBigQuerySchema(TableSchema schema);
+
+  /** Returns the job name as the default BigQuery table name. */
+  class BigQueryTableFactory implements DefaultValueFactory<String> {
+    @Override
+    public String create(PipelineOptions options) {
+      return options.getJobName().replace('-', '_');
+    }
+  }
+}

--- a/buildSrc/src/archetype-resources/src/main/java/common/ExampleOptions.java
+++ b/buildSrc/src/archetype-resources/src/main/java/common/ExampleOptions.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.common;
+
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptions;
+
+/** Options that can be used to configure the Beam examples. */
+public interface ExampleOptions extends PipelineOptions {
+  @Description("Whether to keep jobs running after local process exit")
+  @Default.Boolean(false)
+  boolean getKeepJobsRunning();
+
+  void setKeepJobsRunning(boolean keepJobsRunning);
+
+  @Description("Number of workers to use when executing the injector pipeline")
+  @Default.Integer(1)
+  int getInjectorNumWorkers();
+
+  void setInjectorNumWorkers(int numWorkers);
+}

--- a/buildSrc/src/archetype-resources/src/main/java/common/ExamplePubsubTopicAndSubscriptionOptions.java
+++ b/buildSrc/src/archetype-resources/src/main/java/common/ExamplePubsubTopicAndSubscriptionOptions.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.common;
+
+import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.DefaultValueFactory;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptions;
+
+/** Options that can be used to configure Pub/Sub topic/subscription in Beam examples. */
+public interface ExamplePubsubTopicAndSubscriptionOptions extends ExamplePubsubTopicOptions {
+  @Description("Pub/Sub subscription")
+  @Default.InstanceFactory(PubsubSubscriptionFactory.class)
+  String getPubsubSubscription();
+
+  void setPubsubSubscription(String subscription);
+
+  /** Returns a default Pub/Sub subscription based on the project and the job names. */
+  class PubsubSubscriptionFactory implements DefaultValueFactory<String> {
+    @Override
+    public String create(PipelineOptions options) {
+      return "projects/"
+          + options.as(GcpOptions.class).getProject()
+          + "/subscriptions/"
+          + options.getJobName();
+    }
+  }
+}

--- a/buildSrc/src/archetype-resources/src/main/java/common/ExamplePubsubTopicOptions.java
+++ b/buildSrc/src/archetype-resources/src/main/java/common/ExamplePubsubTopicOptions.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.common;
+
+import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.DefaultValueFactory;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptions;
+
+/** Options that can be used to configure Pub/Sub topic in Beam examples. */
+public interface ExamplePubsubTopicOptions extends GcpOptions {
+  @Description("Pub/Sub topic")
+  @Default.InstanceFactory(PubsubTopicFactory.class)
+  String getPubsubTopic();
+
+  void setPubsubTopic(String topic);
+
+  /** Returns a default Pub/Sub topic based on the project and the job names. */
+  class PubsubTopicFactory implements DefaultValueFactory<String> {
+    @Override
+    public String create(PipelineOptions options) {
+      return "projects/"
+          + options.as(GcpOptions.class).getProject()
+          + "/topics/"
+          + options.getJobName();
+    }
+  }
+}

--- a/buildSrc/src/archetype-resources/src/main/java/common/ExampleUtils.java
+++ b/buildSrc/src/archetype-resources/src/main/java/common/ExampleUtils.java
@@ -1,0 +1,420 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.common;
+
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.googleapis.services.AbstractGoogleClientRequest;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.services.bigquery.Bigquery;
+import com.google.api.services.bigquery.Bigquery.Datasets;
+import com.google.api.services.bigquery.Bigquery.Tables;
+import com.google.api.services.bigquery.model.Dataset;
+import com.google.api.services.bigquery.model.DatasetReference;
+import com.google.api.services.bigquery.model.Table;
+import com.google.api.services.bigquery.model.TableReference;
+import com.google.api.services.bigquery.model.TableSchema;
+import com.google.api.services.pubsub.Pubsub;
+import com.google.api.services.pubsub.model.Subscription;
+import com.google.api.services.pubsub.model.Topic;
+import com.google.auth.Credentials;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.cloud.hadoop.util.ChainingHttpRequestInitializer;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.extensions.gcp.auth.NullCredentialInitializer;
+import org.apache.beam.sdk.extensions.gcp.util.RetryHttpRequestInitializer;
+import org.apache.beam.sdk.extensions.gcp.util.Transport;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryOptions;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubOptions;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.util.BackOff;
+import org.apache.beam.sdk.util.BackOffUtils;
+import org.apache.beam.sdk.util.FluentBackoff;
+import org.apache.beam.sdk.util.Sleeper;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Sets;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.util.concurrent.Uninterruptibles;
+import org.joda.time.Duration;
+
+/**
+ * The utility class that sets up and tears down external resources, and cancels the streaming
+ * pipelines once the program terminates.
+ *
+ * <p>It is used to run Beam examples.
+ */
+public class ExampleUtils {
+
+  private static final int SC_NOT_FOUND = 404;
+
+  /**
+   * \p{L} denotes the category of Unicode letters, so this pattern will match on everything that is
+   * not a letter.
+   *
+   * <p>It is used for tokenizing strings in the wordcount examples.
+   */
+  public static final String TOKENIZER_PATTERN = "[^\\p{L}]+";
+
+  private final PipelineOptions options;
+  private Bigquery bigQueryClient = null;
+  private Pubsub pubsubClient = null;
+  private Set<PipelineResult> pipelinesToCancel = Sets.newHashSet();
+  private List<String> pendingMessages = Lists.newArrayList();
+
+  /** Do resources and runner options setup. */
+  public ExampleUtils(PipelineOptions options) {
+    this.options = options;
+  }
+
+  /**
+   * Sets up external resources that are required by the example, such as Pub/Sub topics and
+   * BigQuery tables.
+   *
+   * @throws IOException if there is a problem setting up the resources
+   */
+  public void setup() throws IOException {
+    Sleeper sleeper = Sleeper.DEFAULT;
+    BackOff backOff =
+        FluentBackoff.DEFAULT.withMaxRetries(3).withInitialBackoff(Duration.millis(200)).backoff();
+    Throwable lastException = null;
+    try {
+      do {
+        try {
+          setupPubsub();
+          setupBigQueryTable();
+          return;
+        } catch (GoogleJsonResponseException e) {
+          lastException = e;
+        }
+      } while (BackOffUtils.next(sleeper, backOff));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      // Ignore InterruptedException
+    }
+    throw new RuntimeException(lastException);
+  }
+
+  /**
+   * Sets up the Google Cloud Pub/Sub topic.
+   *
+   * <p>If the topic doesn't exist, a new topic with the given name will be created.
+   *
+   * @throws IOException if there is a problem setting up the Pub/Sub topic
+   */
+  public void setupPubsub() throws IOException {
+    ExamplePubsubTopicAndSubscriptionOptions pubsubOptions =
+        options.as(ExamplePubsubTopicAndSubscriptionOptions.class);
+    if (!pubsubOptions.getPubsubTopic().isEmpty()) {
+      pendingMessages.add("**********************Set Up Pubsub************************");
+      setupPubsubTopic(pubsubOptions.getPubsubTopic());
+      pendingMessages.add(
+          "The Pub/Sub topic has been set up for this example: " + pubsubOptions.getPubsubTopic());
+
+      if (!pubsubOptions.getPubsubSubscription().isEmpty()) {
+        setupPubsubSubscription(
+            pubsubOptions.getPubsubTopic(), pubsubOptions.getPubsubSubscription());
+        pendingMessages.add(
+            "The Pub/Sub subscription has been set up for this example: "
+                + pubsubOptions.getPubsubSubscription());
+      }
+    }
+  }
+
+  /**
+   * Sets up the BigQuery table with the given schema.
+   *
+   * <p>If the table already exists, the schema has to match the given one. Otherwise, the example
+   * will throw a RuntimeException. If the table doesn't exist, a new table with the given schema
+   * will be created.
+   *
+   * @throws IOException if there is a problem setting up the BigQuery table
+   */
+  public void setupBigQueryTable() throws IOException {
+    ExampleBigQueryTableOptions bigQueryTableOptions =
+        options.as(ExampleBigQueryTableOptions.class);
+    if (bigQueryTableOptions.getBigQueryDataset() != null
+        && bigQueryTableOptions.getBigQueryTable() != null
+        && bigQueryTableOptions.getBigQuerySchema() != null) {
+      pendingMessages.add("******************Set Up Big Query Table*******************");
+      setupBigQueryTable(
+          bigQueryTableOptions.getProject(),
+          bigQueryTableOptions.getBigQueryDataset(),
+          bigQueryTableOptions.getBigQueryTable(),
+          bigQueryTableOptions.getBigQuerySchema());
+      pendingMessages.add(
+          "The BigQuery table has been set up for this example: "
+              + bigQueryTableOptions.getProject()
+              + ":"
+              + bigQueryTableOptions.getBigQueryDataset()
+              + "."
+              + bigQueryTableOptions.getBigQueryTable());
+    }
+  }
+
+  /** Tears down external resources that can be deleted upon the example's completion. */
+  private void tearDown() {
+    pendingMessages.add("*************************Tear Down*************************");
+    ExamplePubsubTopicAndSubscriptionOptions pubsubOptions =
+        options.as(ExamplePubsubTopicAndSubscriptionOptions.class);
+    if (!pubsubOptions.getPubsubTopic().isEmpty()) {
+      try {
+        deletePubsubTopic(pubsubOptions.getPubsubTopic());
+        pendingMessages.add(
+            "The Pub/Sub topic has been deleted: " + pubsubOptions.getPubsubTopic());
+      } catch (IOException e) {
+        pendingMessages.add(
+            "Failed to delete the Pub/Sub topic : " + pubsubOptions.getPubsubTopic());
+      }
+      if (!pubsubOptions.getPubsubSubscription().isEmpty()) {
+        try {
+          deletePubsubSubscription(pubsubOptions.getPubsubSubscription());
+          pendingMessages.add(
+              "The Pub/Sub subscription has been deleted: "
+                  + pubsubOptions.getPubsubSubscription());
+        } catch (IOException e) {
+          pendingMessages.add(
+              "Failed to delete the Pub/Sub subscription : "
+                  + pubsubOptions.getPubsubSubscription());
+        }
+      }
+    }
+
+    ExampleBigQueryTableOptions bigQueryTableOptions =
+        options.as(ExampleBigQueryTableOptions.class);
+    if (bigQueryTableOptions.getBigQueryDataset() != null
+        && bigQueryTableOptions.getBigQueryTable() != null
+        && bigQueryTableOptions.getBigQuerySchema() != null) {
+      pendingMessages.add(
+          "The BigQuery table might contain the example's output, "
+              + "and it is not deleted automatically: "
+              + bigQueryTableOptions.getProject()
+              + ":"
+              + bigQueryTableOptions.getBigQueryDataset()
+              + "."
+              + bigQueryTableOptions.getBigQueryTable());
+      pendingMessages.add(
+          "Please go to the Developers Console to delete it manually."
+              + " Otherwise, you may be charged for its usage.");
+    }
+  }
+
+  /** Returns a BigQuery client builder using the specified {@link BigQueryOptions}. */
+  private static Bigquery.Builder newBigQueryClient(BigQueryOptions options) {
+    return new Bigquery.Builder(
+            Transport.getTransport(),
+            Transport.getJsonFactory(),
+            chainHttpRequestInitializer(
+                options.getGcpCredential(),
+                // Do not log 404. It clutters the output and is possibly even required by the
+                // caller.
+                new RetryHttpRequestInitializer(ImmutableList.of(404))))
+        .setApplicationName(options.getAppName())
+        .setGoogleClientRequestInitializer(options.getGoogleApiTrace());
+  }
+
+  /** Returns a Pubsub client builder using the specified {@link PubsubOptions}. */
+  private static Pubsub.Builder newPubsubClient(PubsubOptions options) {
+    return new Pubsub.Builder(
+            Transport.getTransport(),
+            Transport.getJsonFactory(),
+            chainHttpRequestInitializer(
+                options.getGcpCredential(),
+                // Do not log 404. It clutters the output and is possibly even required by the
+                // caller.
+                new RetryHttpRequestInitializer(ImmutableList.of(404))))
+        .setRootUrl(options.getPubsubRootUrl())
+        .setApplicationName(options.getAppName())
+        .setGoogleClientRequestInitializer(options.getGoogleApiTrace());
+  }
+
+  private static HttpRequestInitializer chainHttpRequestInitializer(
+      Credentials credential, HttpRequestInitializer httpRequestInitializer) {
+    if (credential == null) {
+      return new ChainingHttpRequestInitializer(
+          new NullCredentialInitializer(), httpRequestInitializer);
+    } else {
+      return new ChainingHttpRequestInitializer(
+          new HttpCredentialsAdapter(credential), httpRequestInitializer);
+    }
+  }
+
+  private void setupBigQueryTable(
+      String projectId, String datasetId, String tableId, TableSchema schema) throws IOException {
+    if (bigQueryClient == null) {
+      bigQueryClient = newBigQueryClient(options.as(BigQueryOptions.class)).build();
+    }
+
+    Datasets datasetService = bigQueryClient.datasets();
+    if (executeNullIfNotFound(datasetService.get(projectId, datasetId)) == null) {
+      Dataset newDataset =
+          new Dataset()
+              .setDatasetReference(
+                  new DatasetReference().setProjectId(projectId).setDatasetId(datasetId));
+      datasetService.insert(projectId, newDataset).execute();
+    }
+
+    Tables tableService = bigQueryClient.tables();
+    Table table = executeNullIfNotFound(tableService.get(projectId, datasetId, tableId));
+    if (table == null) {
+      Table newTable =
+          new Table()
+              .setSchema(schema)
+              .setTableReference(
+                  new TableReference()
+                      .setProjectId(projectId)
+                      .setDatasetId(datasetId)
+                      .setTableId(tableId));
+      tableService.insert(projectId, datasetId, newTable).execute();
+    } else if (!table.getSchema().equals(schema)) {
+      throw new RuntimeException(
+          "Table exists and schemas do not match, expecting: "
+              + schema.toPrettyString()
+              + ", actual: "
+              + table.getSchema().toPrettyString());
+    }
+  }
+
+  private void setupPubsubTopic(String topic) throws IOException {
+    if (pubsubClient == null) {
+      pubsubClient = newPubsubClient(options.as(PubsubOptions.class)).build();
+    }
+    if (executeNullIfNotFound(pubsubClient.projects().topics().get(topic)) == null) {
+      pubsubClient.projects().topics().create(topic, new Topic().setName(topic)).execute();
+    }
+  }
+
+  private void setupPubsubSubscription(String topic, String subscription) throws IOException {
+    if (pubsubClient == null) {
+      pubsubClient = newPubsubClient(options.as(PubsubOptions.class)).build();
+    }
+    if (executeNullIfNotFound(pubsubClient.projects().subscriptions().get(subscription)) == null) {
+      Subscription subInfo = new Subscription().setAckDeadlineSeconds(60).setTopic(topic);
+      pubsubClient.projects().subscriptions().create(subscription, subInfo).execute();
+    }
+  }
+
+  /**
+   * Deletes the Google Cloud Pub/Sub topic.
+   *
+   * @throws IOException if there is a problem deleting the Pub/Sub topic
+   */
+  private void deletePubsubTopic(String topic) throws IOException {
+    if (pubsubClient == null) {
+      pubsubClient = newPubsubClient(options.as(PubsubOptions.class)).build();
+    }
+    if (executeNullIfNotFound(pubsubClient.projects().topics().get(topic)) != null) {
+      pubsubClient.projects().topics().delete(topic).execute();
+    }
+  }
+
+  /**
+   * Deletes the Google Cloud Pub/Sub subscription.
+   *
+   * @throws IOException if there is a problem deleting the Pub/Sub subscription
+   */
+  private void deletePubsubSubscription(String subscription) throws IOException {
+    if (pubsubClient == null) {
+      pubsubClient = newPubsubClient(options.as(PubsubOptions.class)).build();
+    }
+    if (executeNullIfNotFound(pubsubClient.projects().subscriptions().get(subscription)) != null) {
+      pubsubClient.projects().subscriptions().delete(subscription).execute();
+    }
+  }
+
+  /** Waits for the pipeline to finish and cancels it before the program exists. */
+  public void waitToFinish(PipelineResult result) {
+    pipelinesToCancel.add(result);
+    if (!options.as(ExampleOptions.class).getKeepJobsRunning()) {
+      addShutdownHook(pipelinesToCancel);
+    }
+    try {
+      result.waitUntilFinish();
+    } catch (UnsupportedOperationException e) {
+      // Do nothing if the given PipelineResult doesn't support waitUntilFinish(),
+      // such as EvaluationResults returned by DirectRunner.
+      tearDown();
+      printPendingMessages();
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to wait the pipeline until finish: " + result);
+    }
+  }
+
+  private void addShutdownHook(final Collection<PipelineResult> pipelineResults) {
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread(
+                () -> {
+                  tearDown();
+                  printPendingMessages();
+                  for (PipelineResult pipelineResult : pipelineResults) {
+                    try {
+                      pipelineResult.cancel();
+                    } catch (IOException e) {
+                      System.out.println("Failed to cancel the job.");
+                      System.out.println(e.getMessage());
+                    }
+                  }
+
+                  for (PipelineResult pipelineResult : pipelineResults) {
+                    boolean cancellationVerified = false;
+                    for (int retryAttempts = 6; retryAttempts > 0; retryAttempts--) {
+                      if (pipelineResult.getState().isTerminal()) {
+                        cancellationVerified = true;
+                        break;
+                      } else {
+                        System.out.println(
+                            "The example pipeline is still running. Verifying the cancellation.");
+                      }
+                      Uninterruptibles.sleepUninterruptibly(10, TimeUnit.SECONDS);
+                    }
+                    if (!cancellationVerified) {
+                      System.out.println(
+                          "Failed to verify the cancellation for job: " + pipelineResult);
+                    }
+                  }
+                }));
+  }
+
+  private void printPendingMessages() {
+    System.out.println();
+    System.out.println("***********************************************************");
+    System.out.println("***********************************************************");
+    for (String message : pendingMessages) {
+      System.out.println(message);
+    }
+    System.out.println("***********************************************************");
+    System.out.println("***********************************************************");
+  }
+
+  private static <T> T executeNullIfNotFound(AbstractGoogleClientRequest<T> request)
+      throws IOException {
+    try {
+      return request.execute();
+    } catch (GoogleJsonResponseException e) {
+      if (e.getStatusCode() == SC_NOT_FOUND) {
+        return null;
+      } else {
+        throw e;
+      }
+    }
+  }
+}

--- a/buildSrc/src/archetype-resources/src/main/java/common/WriteOneFilePerWindow.java
+++ b/buildSrc/src/archetype-resources/src/main/java/common/WriteOneFilePerWindow.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.common;
+
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.MoreObjects.firstNonNull;
+
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.io.FileBasedSink;
+import org.apache.beam.sdk.io.FileBasedSink.FilenamePolicy;
+import org.apache.beam.sdk.io.FileBasedSink.OutputFileHints;
+import org.apache.beam.sdk.io.TextIO;
+import org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions;
+import org.apache.beam.sdk.io.fs.ResourceId;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
+import org.apache.beam.sdk.transforms.windowing.PaneInfo;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PDone;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
+
+/**
+ * A {@link DoFn} that writes elements to files with names deterministically derived from the lower
+ * and upper bounds of their key (an {@link IntervalWindow}).
+ *
+ * <p>This is test utility code, not for end-users, so examples can be focused on their primary
+ * lessons.
+ */
+public class WriteOneFilePerWindow extends PTransform<PCollection<String>, PDone> {
+  private static final DateTimeFormatter FORMATTER = ISODateTimeFormat.hourMinute();
+  private String filenamePrefix;
+  @Nullable private Integer numShards;
+
+  public WriteOneFilePerWindow(String filenamePrefix, Integer numShards) {
+    this.filenamePrefix = filenamePrefix;
+    this.numShards = numShards;
+  }
+
+  @Override
+  public PDone expand(PCollection<String> input) {
+    ResourceId resource = FileBasedSink.convertToFileResourceIfPossible(filenamePrefix);
+    TextIO.Write write =
+        TextIO.write()
+            .to(new PerWindowFiles(resource))
+            .withTempDirectory(resource.getCurrentDirectory())
+            .withWindowedWrites();
+    if (numShards != null) {
+      write = write.withNumShards(numShards);
+    }
+    return input.apply(write);
+  }
+
+  /**
+   * A {@link FilenamePolicy} produces a base file name for a write based on metadata about the data
+   * being written. This always includes the shard number and the total number of shards. For
+   * windowed writes, it also includes the window and pane index (a sequence number assigned to each
+   * trigger firing).
+   */
+  public static class PerWindowFiles extends FilenamePolicy {
+
+    private final ResourceId baseFilename;
+
+    public PerWindowFiles(ResourceId baseFilename) {
+      this.baseFilename = baseFilename;
+    }
+
+    public String filenamePrefixForWindow(IntervalWindow window) {
+      String prefix =
+          baseFilename.isDirectory() ? "" : firstNonNull(baseFilename.getFilename(), "");
+      return String.format(
+          "%s-%s-%s", prefix, FORMATTER.print(window.start()), FORMATTER.print(window.end()));
+    }
+
+    @Override
+    public ResourceId windowedFilename(
+        int shardNumber,
+        int numShards,
+        BoundedWindow window,
+        PaneInfo paneInfo,
+        OutputFileHints outputFileHints) {
+      IntervalWindow intervalWindow = (IntervalWindow) window;
+      String filename =
+          String.format(
+              "%s-%s-of-%s%s",
+              filenamePrefixForWindow(intervalWindow),
+              shardNumber,
+              numShards,
+              outputFileHints.getSuggestedFilenameSuffix());
+      return baseFilename
+          .getCurrentDirectory()
+          .resolve(filename, StandardResolveOptions.RESOLVE_FILE);
+    }
+
+    @Override
+    public ResourceId unwindowedFilename(
+        int shardNumber, int numShards, OutputFileHints outputFileHints) {
+      throw new UnsupportedOperationException("Unsupported.");
+    }
+  }
+}

--- a/buildSrc/src/archetype-resources/src/main/java/complete/game/GameStats.java
+++ b/buildSrc/src/archetype-resources/src/main/java/complete/game/GameStats.java
@@ -1,0 +1,354 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.complete.game;
+
+import java.util.HashMap;
+import java.util.Map;
+import ${package}.common.ExampleUtils;
+import ${package}.complete.game.utils.GameConstants;
+import ${package}.complete.game.utils.WriteWindowedToBigQuery;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Metrics;
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.transforms.Combine;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.Mean;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.Sum;
+import org.apache.beam.sdk.transforms.Values;
+import org.apache.beam.sdk.transforms.View;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.FixedWindows;
+import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
+import org.apache.beam.sdk.transforms.windowing.Sessions;
+import org.apache.beam.sdk.transforms.windowing.TimestampCombiner;
+import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.TypeDescriptors;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class is the fourth in a series of four pipelines that tell a story in a 'gaming' domain,
+ * following {@link UserScore}, {@link HourlyTeamScore}, and {@link LeaderBoard}. New concepts:
+ * session windows and finding session duration; use of both singleton and non-singleton side
+ * inputs.
+ *
+ * <p>This pipeline builds on the {@link LeaderBoard} functionality, and adds some "business
+ * intelligence" analysis: abuse detection and usage patterns. The pipeline derives the Mean user
+ * score sum for a window, and uses that information to identify likely spammers/robots. (The robots
+ * have a higher click rate than the human users). The 'robot' users are then filtered out when
+ * calculating the team scores.
+ *
+ * <p>Additionally, user sessions are tracked: that is, we find bursts of user activity using
+ * session windows. Then, the mean session duration information is recorded in the context of
+ * subsequent fixed windowing. (This could be used to tell us what games are giving us greater user
+ * retention).
+ *
+ * <p>Run {@code org.apache.beam.examples.complete.game.injector.Injector} to generate pubsub data
+ * for this pipeline. The {@code Injector} documentation provides more detail.
+ *
+ * <p>To execute this pipeline, specify the pipeline configuration like this:
+ *
+ * <pre>{@code
+ * --project=YOUR_PROJECT_ID
+ * --tempLocation=gs://YOUR_TEMP_DIRECTORY
+ * --runner=YOUR_RUNNER
+ * --dataset=YOUR-DATASET
+ * --topic=projects/YOUR-PROJECT/topics/YOUR-TOPIC
+ * }</pre>
+ *
+ * <p>The BigQuery dataset you specify must already exist. The PubSub topic you specify should be
+ * the same topic to which the Injector is publishing.
+ */
+public class GameStats extends LeaderBoard {
+
+  /**
+   * Filter out all users but those with a high clickrate, which we will consider as 'spammy' users.
+   * We do this by finding the mean total score per user, then using that information as a side
+   * input to filter out all but those user scores that are larger than {@code (mean *
+   * SCORE_WEIGHT)}.
+   */
+  // [START DocInclude_AbuseDetect]
+  public static class CalculateSpammyUsers
+      extends PTransform<PCollection<KV<String, Integer>>, PCollection<KV<String, Integer>>> {
+    private static final Logger LOG = LoggerFactory.getLogger(CalculateSpammyUsers.class);
+    private static final double SCORE_WEIGHT = 2.5;
+
+    @Override
+    public PCollection<KV<String, Integer>> expand(PCollection<KV<String, Integer>> userScores) {
+
+      // Get the sum of scores for each user.
+      PCollection<KV<String, Integer>> sumScores =
+          userScores.apply("UserSum", Sum.integersPerKey());
+
+      // Extract the score from each element, and use it to find the global mean.
+      final PCollectionView<Double> globalMeanScore =
+          sumScores.apply(Values.create()).apply(Mean.<Integer>globally().asSingletonView());
+
+      // Filter the user sums using the global mean.
+      PCollection<KV<String, Integer>> filtered =
+          sumScores.apply(
+              "ProcessAndFilter",
+              ParDo
+                  // use the derived mean total score as a side input
+                  .of(
+                      new DoFn<KV<String, Integer>, KV<String, Integer>>() {
+                        private final Counter numSpammerUsers =
+                            Metrics.counter("main", "SpammerUsers");
+
+                        @ProcessElement
+                        public void processElement(ProcessContext c) {
+                          Integer score = c.element().getValue();
+                          Double gmc = c.sideInput(globalMeanScore);
+                          if (score > (gmc * SCORE_WEIGHT)) {
+                            LOG.info(
+                                "user "
+                                    + c.element().getKey()
+                                    + " spammer score "
+                                    + score
+                                    + " with mean "
+                                    + gmc);
+                            numSpammerUsers.inc();
+                            c.output(c.element());
+                          }
+                        }
+                      })
+                  .withSideInputs(globalMeanScore));
+      return filtered;
+    }
+  }
+  // [END DocInclude_AbuseDetect]
+
+  /** Calculate and output an element's session duration. */
+  private static class UserSessionInfoFn extends DoFn<KV<String, Integer>, Integer> {
+    @ProcessElement
+    public void processElement(ProcessContext c, BoundedWindow window) {
+      IntervalWindow w = (IntervalWindow) window;
+      int duration = new Duration(w.start(), w.end()).toPeriod().toStandardMinutes().getMinutes();
+      c.output(duration);
+    }
+  }
+
+  /** Options supported by {@link GameStats}. */
+  public interface Options extends LeaderBoard.Options {
+    @Description("Numeric value of fixed window duration for user analysis, in minutes")
+    @Default.Integer(60)
+    Integer getFixedWindowDuration();
+
+    void setFixedWindowDuration(Integer value);
+
+    @Description("Numeric value of gap between user sessions, in minutes")
+    @Default.Integer(5)
+    Integer getSessionGap();
+
+    void setSessionGap(Integer value);
+
+    @Description(
+        "Numeric value of fixed window for finding mean of user session duration, " + "in minutes")
+    @Default.Integer(30)
+    Integer getUserActivityWindowDuration();
+
+    void setUserActivityWindowDuration(Integer value);
+
+    @Description("Prefix used for the BigQuery table names")
+    @Default.String("game_stats")
+    String getGameStatsTablePrefix();
+
+    void setGameStatsTablePrefix(String value);
+  }
+
+  /**
+   * Create a map of information that describes how to write pipeline output to BigQuery. This map
+   * is used to write information about team score sums.
+   */
+  protected static Map<String, WriteWindowedToBigQuery.FieldInfo<KV<String, Integer>>>
+      configureWindowedWrite() {
+    Map<String, WriteWindowedToBigQuery.FieldInfo<KV<String, Integer>>> tableConfigure =
+        new HashMap<>();
+    tableConfigure.put(
+        "team", new WriteWindowedToBigQuery.FieldInfo<>("STRING", (c, w) -> c.element().getKey()));
+    tableConfigure.put(
+        "total_score",
+        new WriteWindowedToBigQuery.FieldInfo<>("INTEGER", (c, w) -> c.element().getValue()));
+    tableConfigure.put(
+        "window_start",
+        new WriteWindowedToBigQuery.FieldInfo<>(
+            "STRING",
+            (c, w) -> {
+              IntervalWindow window = (IntervalWindow) w;
+              return GameConstants.DATE_TIME_FORMATTER.print(window.start());
+            }));
+    tableConfigure.put(
+        "processing_time",
+        new WriteWindowedToBigQuery.FieldInfo<>(
+            "STRING", (c, w) -> GameConstants.DATE_TIME_FORMATTER.print(Instant.now())));
+    return tableConfigure;
+  }
+
+  /**
+   * Create a map of information that describes how to write pipeline output to BigQuery. This map
+   * is used to write information about mean user session time.
+   */
+  protected static Map<String, WriteWindowedToBigQuery.FieldInfo<Double>>
+      configureSessionWindowWrite() {
+
+    Map<String, WriteWindowedToBigQuery.FieldInfo<Double>> tableConfigure = new HashMap<>();
+    tableConfigure.put(
+        "window_start",
+        new WriteWindowedToBigQuery.FieldInfo<>(
+            "STRING",
+            (c, w) -> {
+              IntervalWindow window = (IntervalWindow) w;
+              return GameConstants.DATE_TIME_FORMATTER.print(window.start());
+            }));
+    tableConfigure.put(
+        "mean_duration", new WriteWindowedToBigQuery.FieldInfo<>("FLOAT", (c, w) -> c.element()));
+    return tableConfigure;
+  }
+
+  public static void main(String[] args) throws Exception {
+
+    Options options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
+    // Enforce that this pipeline is always run in streaming mode.
+    options.setStreaming(true);
+    ExampleUtils exampleUtils = new ExampleUtils(options);
+    Pipeline pipeline = Pipeline.create(options);
+
+    // Read Events from Pub/Sub using custom timestamps
+    PCollection<GameActionInfo> rawEvents =
+        pipeline
+            .apply(
+                PubsubIO.readStrings()
+                    .withTimestampAttribute(GameConstants.TIMESTAMP_ATTRIBUTE)
+                    .fromTopic(options.getTopic()))
+            .apply("ParseGameEvent", ParDo.of(new ParseEventFn()));
+
+    // Extract username/score pairs from the event stream
+    PCollection<KV<String, Integer>> userEvents =
+        rawEvents.apply(
+            "ExtractUserScore",
+            MapElements.into(
+                    TypeDescriptors.kvs(TypeDescriptors.strings(), TypeDescriptors.integers()))
+                .via((GameActionInfo gInfo) -> KV.of(gInfo.getUser(), gInfo.getScore())));
+
+    // Calculate the total score per user over fixed windows, and
+    // cumulative updates for late data.
+    final PCollectionView<Map<String, Integer>> spammersView =
+        userEvents
+            .apply(
+                "FixedWindowsUser",
+                Window.into(
+                    FixedWindows.of(Duration.standardMinutes(options.getFixedWindowDuration()))))
+
+            // Filter out everyone but those with (SCORE_WEIGHT * avg) clickrate.
+            // These might be robots/spammers.
+            .apply("CalculateSpammyUsers", new CalculateSpammyUsers())
+            // Derive a view from the collection of spammer users. It will be used as a side input
+            // in calculating the team score sums, below.
+            .apply("CreateSpammersView", View.asMap());
+
+    // [START DocInclude_FilterAndCalc]
+    // Calculate the total score per team over fixed windows,
+    // and emit cumulative updates for late data. Uses the side input derived above-- the set of
+    // suspected robots-- to filter out scores from those users from the sum.
+    // Write the results to BigQuery.
+    rawEvents
+        .apply(
+            "WindowIntoFixedWindows",
+            Window.into(
+                FixedWindows.of(Duration.standardMinutes(options.getFixedWindowDuration()))))
+        // Filter out the detected spammer users, using the side input derived above.
+        .apply(
+            "FilterOutSpammers",
+            ParDo.of(
+                    new DoFn<GameActionInfo, GameActionInfo>() {
+                      @ProcessElement
+                      public void processElement(ProcessContext c) {
+                        // If the user is not in the spammers Map, output the data element.
+                        if (c.sideInput(spammersView).get(c.element().getUser().trim()) == null) {
+                          c.output(c.element());
+                        }
+                      }
+                    })
+                .withSideInputs(spammersView))
+        // Extract and sum teamname/score pairs from the event data.
+        .apply("ExtractTeamScore", new ExtractAndSumScore("team"))
+        // [END DocInclude_FilterAndCalc]
+        // Write the result to BigQuery
+        .apply(
+            "WriteTeamSums",
+            new WriteWindowedToBigQuery<>(
+                options.as(GcpOptions.class).getProject(),
+                options.getDataset(),
+                options.getGameStatsTablePrefix() + "_team",
+                configureWindowedWrite()));
+
+    // [START DocInclude_SessionCalc]
+    // Detect user sessions-- that is, a burst of activity separated by a gap from further
+    // activity. Find and record the mean session lengths.
+    // This information could help the game designers track the changing user engagement
+    // as their set of games changes.
+    userEvents
+        .apply(
+            "WindowIntoSessions",
+            Window.<KV<String, Integer>>into(
+                    Sessions.withGapDuration(Duration.standardMinutes(options.getSessionGap())))
+                .withTimestampCombiner(TimestampCombiner.END_OF_WINDOW))
+        // For this use, we care only about the existence of the session, not any particular
+        // information aggregated over it, so the following is an efficient way to do that.
+        .apply(Combine.perKey(x -> 0))
+        // Get the duration per session.
+        .apply("UserSessionActivity", ParDo.of(new UserSessionInfoFn()))
+        // [END DocInclude_SessionCalc]
+        // [START DocInclude_Rewindow]
+        // Re-window to process groups of session sums according to when the sessions complete.
+        .apply(
+            "WindowToExtractSessionMean",
+            Window.into(
+                FixedWindows.of(Duration.standardMinutes(options.getUserActivityWindowDuration()))))
+        // Find the mean session duration in each window.
+        .apply(Mean.<Integer>globally().withoutDefaults())
+        // Write this info to a BigQuery table.
+        .apply(
+            "WriteAvgSessionLength",
+            new WriteWindowedToBigQuery<>(
+                options.as(GcpOptions.class).getProject(),
+                options.getDataset(),
+                options.getGameStatsTablePrefix() + "_sessions",
+                configureSessionWindowWrite()));
+    // [END DocInclude_Rewindow]
+
+    // Run the pipeline and wait for the pipeline to finish; capture cancellation requests from the
+    // command line.
+    PipelineResult result = pipeline.run();
+    exampleUtils.waitToFinish(result);
+  }
+}

--- a/buildSrc/src/archetype-resources/src/main/java/complete/game/HourlyTeamScore.java
+++ b/buildSrc/src/archetype-resources/src/main/java/complete/game/HourlyTeamScore.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.complete.game;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TimeZone;
+import ${package}.complete.game.utils.GameConstants;
+import ${package}.complete.game.utils.WriteToText;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.io.TextIO;
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.transforms.Filter;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.WithTimestamps;
+import org.apache.beam.sdk.transforms.windowing.FixedWindows;
+import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
+import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.values.KV;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
+/**
+ * This class is the second in a series of four pipelines that tell a story in a 'gaming' domain,
+ * following {@link UserScore}. In addition to the concepts introduced in {@link UserScore}, new
+ * concepts include: windowing and element timestamps; use of {@code Filter.by()}.
+ *
+ * <p>This pipeline processes data collected from gaming events in batch, building on {@link
+ * UserScore} but using fixed windows. It calculates the sum of scores per team, for each window,
+ * optionally allowing specification of two timestamps before and after which data is filtered out.
+ * This allows a model where late data collected after the intended analysis window can be included,
+ * and any late-arriving data prior to the beginning of the analysis window can be removed as well.
+ * By using windowing and adding element timestamps, we can do finer-grained analysis than with the
+ * {@link UserScore} pipeline. However, our batch processing is high-latency, in that we don't get
+ * results from plays at the beginning of the batch's time period until the batch is processed.
+ *
+ * <p>To execute this pipeline, specify the pipeline configuration like this:
+ *
+ * <pre>{@code
+ * --tempLocation=YOUR_TEMP_DIRECTORY
+ * --runner=YOUR_RUNNER
+ * --output=YOUR_OUTPUT_DIRECTORY
+ * (possibly options specific to your runner or permissions for your temp/output locations)
+ * }</pre>
+ *
+ * <p>Optionally include {@code --input} to specify the batch input file path. To indicate a time
+ * after which the data should be filtered out, include the {@code --stopMin} arg. E.g., {@code
+ * --stopMin=2015-10-18-23-59} indicates that any data timestamped after 23:59 PST on 2015-10-18
+ * should not be included in the analysis. To indicate a time before which data should be filtered
+ * out, include the {@code --startMin} arg. If you're using the default input specified in {@link
+ * UserScore}, "gs://apache-beam-samples/game/gaming_data*.csv", then {@code
+ * --startMin=2015-11-16-16-10 --stopMin=2015-11-17-16-10} are good values.
+ */
+public class HourlyTeamScore extends UserScore {
+
+  private static DateTimeFormatter minFmt =
+      DateTimeFormat.forPattern("yyyy-MM-dd-HH-mm")
+          .withZone(DateTimeZone.forTimeZone(TimeZone.getTimeZone("America/Los_Angeles")));
+
+  /** Options supported by {@link HourlyTeamScore}. */
+  public interface Options extends UserScore.Options {
+
+    @Description("Numeric value of fixed window duration, in minutes")
+    @Default.Integer(60)
+    Integer getWindowDuration();
+
+    void setWindowDuration(Integer value);
+
+    @Description(
+        "String representation of the first minute after which to generate results,"
+            + "in the format: yyyy-MM-dd-HH-mm . This time should be in PST."
+            + "Any input data timestamped prior to that minute won't be included in the sums.")
+    @Default.String("1970-01-01-00-00")
+    String getStartMin();
+
+    void setStartMin(String value);
+
+    @Description(
+        "String representation of the first minute for which to not generate results,"
+            + "in the format: yyyy-MM-dd-HH-mm . This time should be in PST."
+            + "Any input data timestamped after that minute won't be included in the sums.")
+    @Default.String("2100-01-01-00-00")
+    String getStopMin();
+
+    void setStopMin(String value);
+  }
+
+  /**
+   * Create a map of information that describes how to write pipeline output to text. This map is
+   * passed to the {@link WriteToText} constructor to write team score sums and includes information
+   * about window start time.
+   */
+  protected static Map<String, WriteToText.FieldFn<KV<String, Integer>>> configureOutput() {
+    Map<String, WriteToText.FieldFn<KV<String, Integer>>> config = new HashMap<>();
+    config.put("team", (c, w) -> c.element().getKey());
+    config.put("total_score", (c, w) -> c.element().getValue());
+    config.put(
+        "window_start",
+        (c, w) -> {
+          IntervalWindow window = (IntervalWindow) w;
+          return GameConstants.DATE_TIME_FORMATTER.print(window.start());
+        });
+    return config;
+  }
+
+  /** Run a batch pipeline to do windowed analysis of the data. */
+  // [START DocInclude_HTSMain]
+  public static void main(String[] args) throws Exception {
+    // Begin constructing a pipeline configured by commandline flags.
+    Options options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
+    Pipeline pipeline = Pipeline.create(options);
+
+    final Instant stopMinTimestamp = new Instant(minFmt.parseMillis(options.getStopMin()));
+    final Instant startMinTimestamp = new Instant(minFmt.parseMillis(options.getStartMin()));
+
+    // Read 'gaming' events from a text file.
+    pipeline
+        .apply(TextIO.read().from(options.getInput()))
+        // Parse the incoming data.
+        .apply("ParseGameEvent", ParDo.of(new ParseEventFn()))
+
+        // Filter out data before and after the given times so that it is not included
+        // in the calculations. As we collect data in batches (say, by day), the batch for the day
+        // that we want to analyze could potentially include some late-arriving data from the
+        // previous day.
+        // If so, we want to weed it out. Similarly, if we include data from the following day
+        // (to scoop up late-arriving events from the day we're analyzing), we need to weed out
+        // events that fall after the time period we want to analyze.
+        // [START DocInclude_HTSFilters]
+        .apply(
+            "FilterStartTime",
+            Filter.by(
+                (GameActionInfo gInfo) -> gInfo.getTimestamp() > startMinTimestamp.getMillis()))
+        .apply(
+            "FilterEndTime",
+            Filter.by(
+                (GameActionInfo gInfo) -> gInfo.getTimestamp() < stopMinTimestamp.getMillis()))
+        // [END DocInclude_HTSFilters]
+
+        // [START DocInclude_HTSAddTsAndWindow]
+        // Add an element timestamp based on the event log, and apply fixed windowing.
+        .apply(
+            "AddEventTimestamps",
+            WithTimestamps.of((GameActionInfo i) -> new Instant(i.getTimestamp())))
+        .apply(
+            "FixedWindowsTeam",
+            Window.into(FixedWindows.of(Duration.standardMinutes(options.getWindowDuration()))))
+        // [END DocInclude_HTSAddTsAndWindow]
+
+        // Extract and sum teamname/score pairs from the event data.
+        .apply("ExtractTeamScore", new ExtractAndSumScore("team"))
+        .apply(
+            "WriteTeamScoreSums", new WriteToText<>(options.getOutput(), configureOutput(), true));
+
+    pipeline.run().waitUntilFinish();
+  }
+  // [END DocInclude_HTSMain]
+
+}

--- a/buildSrc/src/archetype-resources/src/main/java/complete/game/LeaderBoard.java
+++ b/buildSrc/src/archetype-resources/src/main/java/complete/game/LeaderBoard.java
@@ -1,0 +1,313 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.complete.game;
+
+import java.util.HashMap;
+import java.util.Map;
+import ${package}.common.ExampleOptions;
+import ${package}.common.ExampleUtils;
+import ${package}.complete.game.utils.GameConstants;
+import ${package}.complete.game.utils.WriteToBigQuery;
+import ${package}.complete.game.utils.WriteWindowedToBigQuery;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.StreamingOptions;
+import org.apache.beam.sdk.options.Validation;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.windowing.AfterProcessingTime;
+import org.apache.beam.sdk.transforms.windowing.AfterWatermark;
+import org.apache.beam.sdk.transforms.windowing.FixedWindows;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
+import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
+import org.apache.beam.sdk.transforms.windowing.Repeatedly;
+import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+
+/**
+ * This class is the third in a series of four pipelines that tell a story in a 'gaming' domain,
+ * following {@link UserScore} and {@link HourlyTeamScore}. Concepts include: processing unbounded
+ * data using fixed windows; use of custom timestamps and event-time processing; generation of
+ * early/speculative results; using .accumulatingFiredPanes() to do cumulative processing of late-
+ * arriving data.
+ *
+ * <p>This pipeline processes an unbounded stream of 'game events'. The calculation of the team
+ * scores uses fixed windowing based on event time (the time of the game play event), not processing
+ * time (the time that an event is processed by the pipeline). The pipeline calculates the sum of
+ * scores per team, for each window. By default, the team scores are calculated using one-hour
+ * windows.
+ *
+ * <p>In contrast-- to demo another windowing option-- the user scores are calculated using a global
+ * window, which periodically (every ten minutes) emits cumulative user score sums.
+ *
+ * <p>In contrast to the previous pipelines in the series, which used static, finite input data,
+ * here we're using an unbounded data source, which lets us provide speculative results, and allows
+ * handling of late data, at much lower latency. We can use the early/speculative results to keep a
+ * 'leaderboard' updated in near-realtime. Our handling of late data lets us generate correct
+ * results, e.g. for 'team prizes'. We're now outputting window results as they're calculated,
+ * giving us much lower latency than with the previous batch examples.
+ *
+ * <p>Run {@code injector.Injector} to generate pubsub data for this pipeline. The Injector
+ * documentation provides more detail on how to do this.
+ *
+ * <p>To execute this pipeline, specify the pipeline configuration like this:
+ *
+ * <pre>{@code
+ * --project=YOUR_PROJECT_ID
+ * --tempLocation=gs://YOUR_TEMP_DIRECTORY
+ * --runner=YOUR_RUNNER
+ * --dataset=YOUR-DATASET
+ * --topic=projects/YOUR-PROJECT/topics/YOUR-TOPIC
+ * }</pre>
+ *
+ * <p>The BigQuery dataset you specify must already exist. The PubSub topic you specify should be
+ * the same topic to which the Injector is publishing.
+ */
+public class LeaderBoard extends HourlyTeamScore {
+
+  static final Duration FIVE_MINUTES = Duration.standardMinutes(5);
+  static final Duration TEN_MINUTES = Duration.standardMinutes(10);
+
+  /** Options supported by {@link LeaderBoard}. */
+  public interface Options extends ExampleOptions, StreamingOptions {
+
+    @Description("BigQuery Dataset to write tables to. Must already exist.")
+    @Validation.Required
+    String getDataset();
+
+    void setDataset(String value);
+
+    @Description("Pub/Sub topic to read from")
+    @Validation.Required
+    String getTopic();
+
+    void setTopic(String value);
+
+    @Description("Numeric value of fixed window duration for team analysis, in minutes")
+    @Default.Integer(60)
+    Integer getTeamWindowDuration();
+
+    void setTeamWindowDuration(Integer value);
+
+    @Description("Numeric value of allowed data lateness, in minutes")
+    @Default.Integer(120)
+    Integer getAllowedLateness();
+
+    void setAllowedLateness(Integer value);
+
+    @Description("Prefix used for the BigQuery table names")
+    @Default.String("leaderboard")
+    String getLeaderBoardTableName();
+
+    void setLeaderBoardTableName(String value);
+  }
+
+  /**
+   * Create a map of information that describes how to write pipeline output to BigQuery. This map
+   * is used to write team score sums and includes event timing information.
+   */
+  protected static Map<String, WriteWindowedToBigQuery.FieldInfo<KV<String, Integer>>>
+      configureWindowedTableWrite() {
+
+    Map<String, WriteWindowedToBigQuery.FieldInfo<KV<String, Integer>>> tableConfigure =
+        new HashMap<>();
+    tableConfigure.put(
+        "team", new WriteWindowedToBigQuery.FieldInfo<>("STRING", (c, w) -> c.element().getKey()));
+    tableConfigure.put(
+        "total_score",
+        new WriteWindowedToBigQuery.FieldInfo<>("INTEGER", (c, w) -> c.element().getValue()));
+    tableConfigure.put(
+        "window_start",
+        new WriteWindowedToBigQuery.FieldInfo<>(
+            "STRING",
+            (c, w) -> {
+              IntervalWindow window = (IntervalWindow) w;
+              return GameConstants.DATE_TIME_FORMATTER.print(window.start());
+            }));
+    tableConfigure.put(
+        "processing_time",
+        new WriteWindowedToBigQuery.FieldInfo<>(
+            "STRING", (c, w) -> GameConstants.DATE_TIME_FORMATTER.print(Instant.now())));
+    tableConfigure.put(
+        "timing",
+        new WriteWindowedToBigQuery.FieldInfo<>(
+            "STRING", (c, w) -> c.pane().getTiming().toString()));
+    return tableConfigure;
+  }
+
+  /**
+   * Create a map of information that describes how to write pipeline output to BigQuery. This map
+   * is passed to the {@link WriteToBigQuery} constructor to write user score sums.
+   */
+  protected static Map<String, WriteToBigQuery.FieldInfo<KV<String, Integer>>>
+      configureBigQueryWrite() {
+    Map<String, WriteToBigQuery.FieldInfo<KV<String, Integer>>> tableConfigure = new HashMap<>();
+    tableConfigure.put(
+        "user", new WriteToBigQuery.FieldInfo<>("STRING", (c, w) -> c.element().getKey()));
+    tableConfigure.put(
+        "total_score",
+        new WriteToBigQuery.FieldInfo<>("INTEGER", (c, w) -> c.element().getValue()));
+    return tableConfigure;
+  }
+
+  /**
+   * Create a map of information that describes how to write pipeline output to BigQuery. This map
+   * is used to write user score sums.
+   */
+  protected static Map<String, WriteToBigQuery.FieldInfo<KV<String, Integer>>>
+      configureGlobalWindowBigQueryWrite() {
+
+    Map<String, WriteToBigQuery.FieldInfo<KV<String, Integer>>> tableConfigure =
+        configureBigQueryWrite();
+    tableConfigure.put(
+        "processing_time",
+        new WriteToBigQuery.FieldInfo<>(
+            "STRING", (c, w) -> GameConstants.DATE_TIME_FORMATTER.print(Instant.now())));
+    return tableConfigure;
+  }
+
+  public static void main(String[] args) throws Exception {
+
+    Options options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
+    // Enforce that this pipeline is always run in streaming mode.
+    options.setStreaming(true);
+    ExampleUtils exampleUtils = new ExampleUtils(options);
+    Pipeline pipeline = Pipeline.create(options);
+
+    // Read game events from Pub/Sub using custom timestamps, which are extracted from the pubsub
+    // data elements, and parse the data.
+    PCollection<GameActionInfo> gameEvents =
+        pipeline
+            .apply(
+                PubsubIO.readStrings()
+                    .withTimestampAttribute(GameConstants.TIMESTAMP_ATTRIBUTE)
+                    .fromTopic(options.getTopic()))
+            .apply("ParseGameEvent", ParDo.of(new ParseEventFn()));
+
+    gameEvents
+        .apply(
+            "CalculateTeamScores",
+            new CalculateTeamScores(
+                Duration.standardMinutes(options.getTeamWindowDuration()),
+                Duration.standardMinutes(options.getAllowedLateness())))
+        // Write the results to BigQuery.
+        .apply(
+            "WriteTeamScoreSums",
+            new WriteWindowedToBigQuery<>(
+                options.as(GcpOptions.class).getProject(),
+                options.getDataset(),
+                options.getLeaderBoardTableName() + "_team",
+                configureWindowedTableWrite()));
+    gameEvents
+        .apply(
+            "CalculateUserScores",
+            new CalculateUserScores(Duration.standardMinutes(options.getAllowedLateness())))
+        // Write the results to BigQuery.
+        .apply(
+            "WriteUserScoreSums",
+            new WriteToBigQuery<>(
+                options.as(GcpOptions.class).getProject(),
+                options.getDataset(),
+                options.getLeaderBoardTableName() + "_user",
+                configureGlobalWindowBigQueryWrite()));
+
+    // Run the pipeline and wait for the pipeline to finish; capture cancellation requests from the
+    // command line.
+    PipelineResult result = pipeline.run();
+    exampleUtils.waitToFinish(result);
+  }
+
+  /** Calculates scores for each team within the configured window duration. */
+  // [START DocInclude_WindowAndTrigger]
+  // Extract team/score pairs from the event stream, using hour-long windows by default.
+  @VisibleForTesting
+  static class CalculateTeamScores
+      extends PTransform<PCollection<GameActionInfo>, PCollection<KV<String, Integer>>> {
+    private final Duration teamWindowDuration;
+    private final Duration allowedLateness;
+
+    CalculateTeamScores(Duration teamWindowDuration, Duration allowedLateness) {
+      this.teamWindowDuration = teamWindowDuration;
+      this.allowedLateness = allowedLateness;
+    }
+
+    @Override
+    public PCollection<KV<String, Integer>> expand(PCollection<GameActionInfo> infos) {
+      return infos
+          .apply(
+              "LeaderboardTeamFixedWindows",
+              Window.<GameActionInfo>into(FixedWindows.of(teamWindowDuration))
+                  // We will get early (speculative) results as well as cumulative
+                  // processing of late data.
+                  .triggering(
+                      AfterWatermark.pastEndOfWindow()
+                          .withEarlyFirings(
+                              AfterProcessingTime.pastFirstElementInPane()
+                                  .plusDelayOf(FIVE_MINUTES))
+                          .withLateFirings(
+                              AfterProcessingTime.pastFirstElementInPane()
+                                  .plusDelayOf(TEN_MINUTES)))
+                  .withAllowedLateness(allowedLateness)
+                  .accumulatingFiredPanes())
+          // Extract and sum teamname/score pairs from the event data.
+          .apply("ExtractTeamScore", new ExtractAndSumScore("team"));
+    }
+  }
+  // [END DocInclude_WindowAndTrigger]
+
+  // [START DocInclude_ProcTimeTrigger]
+  /**
+   * Extract user/score pairs from the event stream using processing time, via global windowing. Get
+   * periodic updates on all users' running scores.
+   */
+  @VisibleForTesting
+  static class CalculateUserScores
+      extends PTransform<PCollection<GameActionInfo>, PCollection<KV<String, Integer>>> {
+    private final Duration allowedLateness;
+
+    CalculateUserScores(Duration allowedLateness) {
+      this.allowedLateness = allowedLateness;
+    }
+
+    @Override
+    public PCollection<KV<String, Integer>> expand(PCollection<GameActionInfo> input) {
+      return input
+          .apply(
+              "LeaderboardUserGlobalWindow",
+              Window.<GameActionInfo>into(new GlobalWindows())
+                  // Get periodic results every ten minutes.
+                  .triggering(
+                      Repeatedly.forever(
+                          AfterProcessingTime.pastFirstElementInPane().plusDelayOf(TEN_MINUTES)))
+                  .accumulatingFiredPanes()
+                  .withAllowedLateness(allowedLateness))
+          // Extract and sum username/score pairs from the event data.
+          .apply("ExtractUserScore", new ExtractAndSumScore("user"));
+    }
+  }
+  // [END DocInclude_ProcTimeTrigger]
+}

--- a/buildSrc/src/archetype-resources/src/main/java/complete/game/StatefulTeamScore.java
+++ b/buildSrc/src/archetype-resources/src/main/java/complete/game/StatefulTeamScore.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.complete.game;
+
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.MoreObjects.firstNonNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import ${package}.common.ExampleUtils;
+import ${package}.complete.game.utils.GameConstants;
+import ${package}.complete.game.utils.WriteToBigQuery.FieldInfo;
+import ${package}.complete.game.utils.WriteWindowedToBigQuery;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.coders.VarIntCoder;
+import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.state.StateSpec;
+import org.apache.beam.sdk.state.StateSpecs;
+import org.apache.beam.sdk.state.ValueState;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.TypeDescriptor;
+import org.apache.beam.sdk.values.TypeDescriptors;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
+import org.joda.time.Instant;
+
+/**
+ * This class is part of a series of pipelines that tell a story in a gaming domain. Concepts
+ * include: stateful processing.
+ *
+ * <p>This pipeline processes an unbounded stream of 'game events'. It uses stateful processing to
+ * aggregate team scores per team and outputs team name and it's total score every time the team
+ * passes a new multiple of a threshold score. For example, multiples of the threshold could be the
+ * corresponding scores required to pass each level of the game. By default, this threshold is set
+ * to 5000.
+ *
+ * <p>Stateful processing allows us to write pipelines that output based on a runtime state (when a
+ * team reaches a certain score, in every 100 game events etc) without time triggers. See
+ * https://beam.apache.org/blog/2017/02/13/stateful-processing.html for more information on using
+ * stateful processing.
+ *
+ * <p>Run {@code injector.Injector} to generate pubsub data for this pipeline. The Injector
+ * documentation provides more detail on how to do this.
+ *
+ * <p>To execute this pipeline, specify the pipeline configuration like this:
+ *
+ * <pre>{@code
+ * --project=YOUR_PROJECT_ID
+ * --tempLocation=gs://YOUR_TEMP_DIRECTORY
+ * --runner=YOUR_RUNNER
+ * --dataset=YOUR-DATASET
+ * --topic=projects/YOUR-PROJECT/topics/YOUR-TOPIC
+ * }</pre>
+ *
+ * <p>The BigQuery dataset you specify must already exist. The PubSub topic you specify should be
+ * the same topic to which the Injector is publishing.
+ */
+public class StatefulTeamScore extends LeaderBoard {
+
+  /** Options supported by {@link StatefulTeamScore}. */
+  public interface Options extends LeaderBoard.Options {
+
+    @Description("Numeric value, multiple of which is used as threshold for outputting team score.")
+    @Default.Integer(5000)
+    Integer getThresholdScore();
+
+    void setThresholdScore(Integer value);
+  }
+
+  /**
+   * Create a map of information that describes how to write pipeline output to BigQuery. This map
+   * is used to write team score sums.
+   */
+  private static Map<String, FieldInfo<KV<String, Integer>>> configureCompleteWindowedTableWrite() {
+
+    Map<String, WriteWindowedToBigQuery.FieldInfo<KV<String, Integer>>> tableConfigure =
+        new HashMap<>();
+    tableConfigure.put(
+        "team", new WriteWindowedToBigQuery.FieldInfo<>("STRING", (c, w) -> c.element().getKey()));
+    tableConfigure.put(
+        "total_score",
+        new WriteWindowedToBigQuery.FieldInfo<>("INTEGER", (c, w) -> c.element().getValue()));
+    tableConfigure.put(
+        "processing_time",
+        new WriteWindowedToBigQuery.FieldInfo<>(
+            "STRING", (c, w) -> GameConstants.DATE_TIME_FORMATTER.print(Instant.now())));
+    return tableConfigure;
+  }
+
+  public static void main(String[] args) throws Exception {
+
+    Options options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
+    // Enforce that this pipeline is always run in streaming mode.
+    options.setStreaming(true);
+    ExampleUtils exampleUtils = new ExampleUtils(options);
+    Pipeline pipeline = Pipeline.create(options);
+
+    pipeline
+        // Read game events from Pub/Sub using custom timestamps, which are extracted from the
+        // pubsub data elements, and parse the data.
+        .apply(
+            PubsubIO.readStrings()
+                .withTimestampAttribute(GameConstants.TIMESTAMP_ATTRIBUTE)
+                .fromTopic(options.getTopic()))
+        .apply("ParseGameEvent", ParDo.of(new ParseEventFn()))
+        // Create <team, GameActionInfo> mapping. UpdateTeamScore uses team name as key.
+        .apply(
+            "MapTeamAsKey",
+            MapElements.into(
+                    TypeDescriptors.kvs(
+                        TypeDescriptors.strings(), TypeDescriptor.of(GameActionInfo.class)))
+                .via((GameActionInfo gInfo) -> KV.of(gInfo.team, gInfo)))
+        // Outputs a team's score every time it passes a new multiple of the threshold.
+        .apply("UpdateTeamScore", ParDo.of(new UpdateTeamScoreFn(options.getThresholdScore())))
+        // Write the results to BigQuery.
+        .apply(
+            "WriteTeamLeaders",
+            new WriteWindowedToBigQuery<>(
+                options.as(GcpOptions.class).getProject(),
+                options.getDataset(),
+                options.getLeaderBoardTableName() + "_team_leader",
+                configureCompleteWindowedTableWrite()));
+
+    // Run the pipeline and wait for the pipeline to finish; capture cancellation requests from the
+    // command line.
+    PipelineResult result = pipeline.run();
+    exampleUtils.waitToFinish(result);
+  }
+
+  /**
+   * Tracks each team's score separately in a single state cell and outputs the score every time it
+   * passes a new multiple of a threshold.
+   *
+   * <p>We use stateful {@link DoFn} because:
+   *
+   * <ul>
+   *   <li>State is key-partitioned. Therefore, the score is calculated per team.
+   *   <li>Stateful {@link DoFn} can determine when to output based on the state. This only allows
+   *       outputting when a team's score passes a given threshold.
+   * </ul>
+   */
+  @VisibleForTesting
+  public static class UpdateTeamScoreFn
+      extends DoFn<KV<String, GameActionInfo>, KV<String, Integer>> {
+
+    private static final String TOTAL_SCORE = "totalScore";
+    private final int thresholdScore;
+
+    public UpdateTeamScoreFn(int thresholdScore) {
+      this.thresholdScore = thresholdScore;
+    }
+
+    /**
+     * Describes the state for storing team score. Let's break down this statement.
+     *
+     * <p>{@link StateSpec} configures the state cell, which is provided by a runner during pipeline
+     * execution.
+     *
+     * <p>{@link org.apache.beam.sdk.transforms.DoFn.StateId} annotation assigns an identifier to
+     * the state, which is used to refer the state in {@link
+     * org.apache.beam.sdk.transforms.DoFn.ProcessElement}.
+     *
+     * <p>A {@link ValueState} stores single value per key and per window. Because our pipeline is
+     * globally windowed in this example, this {@link ValueState} is just key partitioned, with one
+     * score per team. Any other class that extends {@link org.apache.beam.sdk.state.State} can be
+     * used.
+     *
+     * <p>In order to store the value, the state must be encoded. Therefore, we provide a coder, in
+     * this case the {@link VarIntCoder}. If the coder is not provided as in {@code
+     * StateSpecs.value()}, Beam's coder inference will try to provide a coder automatically.
+     */
+    @StateId(TOTAL_SCORE)
+    private final StateSpec<ValueState<Integer>> totalScoreSpec =
+        StateSpecs.value(VarIntCoder.of());
+
+    /**
+     * To use a state cell, annotate a parameter with {@link
+     * org.apache.beam.sdk.transforms.DoFn.StateId} that matches the state declaration. The type of
+     * the parameter should match the {@link StateSpec} type.
+     */
+    @ProcessElement
+    public void processElement(
+        ProcessContext c, @StateId(TOTAL_SCORE) ValueState<Integer> totalScore) {
+      String teamName = c.element().getKey();
+      GameActionInfo gInfo = c.element().getValue();
+
+      // ValueState cells do not contain a default value. If the state is possibly not written, make
+      // sure to check for null on read.
+      int oldTotalScore = firstNonNull(totalScore.read(), 0);
+      totalScore.write(oldTotalScore + gInfo.score);
+
+      // Since there are no negative scores, the easiest way to check whether a team just passed a
+      // new multiple of the threshold score is to compare the quotients of dividing total scores by
+      // threshold before and after this aggregation. For example, if the total score was 1999,
+      // the new total is 2002, and the threshold is 1000, 1999 / 1000 = 1, 2002 / 1000 = 2.
+      // Therefore, this team passed the threshold.
+      if (oldTotalScore / this.thresholdScore < totalScore.read() / this.thresholdScore) {
+        c.output(KV.of(teamName, totalScore.read()));
+      }
+    }
+  }
+}

--- a/buildSrc/src/archetype-resources/src/main/java/complete/game/UserScore.java
+++ b/buildSrc/src/archetype-resources/src/main/java/complete/game/UserScore.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.complete.game;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.avro.reflect.Nullable;
+import ${package}.complete.game.utils.WriteToText;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.coders.AvroCoder;
+import org.apache.beam.sdk.coders.DefaultCoder;
+import org.apache.beam.sdk.io.TextIO;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Metrics;
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.Validation;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.Sum;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TypeDescriptors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class is the first in a series of four pipelines that tell a story in a 'gaming' domain.
+ * Concepts: batch processing, reading input from text files, writing output to text files, using
+ * standalone DoFns, use of the sum per key transform, and use of Java 8 lambda syntax.
+ *
+ * <p>In this gaming scenario, many users play, as members of different teams, over the course of a
+ * day, and their actions are logged for processing. Some of the logged game events may be late-
+ * arriving, if users play on mobile devices and go transiently offline for a period.
+ *
+ * <p>This pipeline does batch processing of data collected from gaming events. It calculates the
+ * sum of scores per user, over an entire batch of gaming data (collected, say, for each day). The
+ * batch processing will not include any late data that arrives after the day's cutoff point.
+ *
+ * <p>To execute this pipeline, specify the pipeline configuration like this:
+ *
+ * <pre>{@code
+ * --tempLocation=YOUR_TEMP_DIRECTORY
+ * --runner=YOUR_RUNNER
+ * --output=YOUR_OUTPUT_DIRECTORY
+ * (possibly options specific to your runner or permissions for your temp/output locations)
+ * }</pre>
+ *
+ * <p>Optionally include the --input argument to specify a batch input file. See the --input default
+ * value for example batch data file, or use {@code injector.Injector} to generate your own batch
+ * data.
+ */
+public class UserScore {
+
+  /** Class to hold info about a game event. */
+  @DefaultCoder(AvroCoder.class)
+  static class GameActionInfo {
+    @Nullable String user;
+    @Nullable String team;
+    @Nullable Integer score;
+    @Nullable Long timestamp;
+
+    public GameActionInfo() {}
+
+    public GameActionInfo(String user, String team, Integer score, Long timestamp) {
+      this.user = user;
+      this.team = team;
+      this.score = score;
+      this.timestamp = timestamp;
+    }
+
+    public String getUser() {
+      return this.user;
+    }
+
+    public String getTeam() {
+      return this.team;
+    }
+
+    public Integer getScore() {
+      return this.score;
+    }
+
+    public Long getTimestamp() {
+      return this.timestamp;
+    }
+
+    public String getKey(String keyname) {
+      if ("team".equals(keyname)) {
+        return this.team;
+      } else { // return username as default
+        return this.user;
+      }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || o.getClass() != this.getClass()) {
+        return false;
+      }
+
+      GameActionInfo gameActionInfo = (GameActionInfo) o;
+
+      if (!this.getUser().equals(gameActionInfo.getUser())) {
+        return false;
+      }
+
+      if (!this.getTeam().equals(gameActionInfo.getTeam())) {
+        return false;
+      }
+
+      if (!this.getScore().equals(gameActionInfo.getScore())) {
+        return false;
+      }
+
+      return this.getTimestamp().equals(gameActionInfo.getTimestamp());
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(user, team, score, timestamp);
+    }
+  }
+
+  /**
+   * Parses the raw game event info into GameActionInfo objects. Each event line has the following
+   * format: username,teamname,score,timestamp_in_ms,readable_time e.g.:
+   * user2_AsparagusPig,AsparagusPig,10,1445230923951,2015-11-02 09:09:28.224 The human-readable
+   * time string is not used here.
+   */
+  static class ParseEventFn extends DoFn<String, GameActionInfo> {
+
+    // Log and count parse errors.
+    private static final Logger LOG = LoggerFactory.getLogger(ParseEventFn.class);
+    private final Counter numParseErrors = Metrics.counter("main", "ParseErrors");
+
+    @ProcessElement
+    public void processElement(ProcessContext c) {
+      String[] components = c.element().split(",", -1);
+      try {
+        String user = components[0].trim();
+        String team = components[1].trim();
+        Integer score = Integer.parseInt(components[2].trim());
+        Long timestamp = Long.parseLong(components[3].trim());
+        GameActionInfo gInfo = new GameActionInfo(user, team, score, timestamp);
+        c.output(gInfo);
+      } catch (ArrayIndexOutOfBoundsException | NumberFormatException e) {
+        numParseErrors.inc();
+        LOG.info("Parse error on " + c.element() + ", " + e.getMessage());
+      }
+    }
+  }
+
+  /**
+   * A transform to extract key/score information from GameActionInfo, and sum the scores. The
+   * constructor arg determines whether 'team' or 'user' info is extracted.
+   */
+  // [START DocInclude_USExtractXform]
+  public static class ExtractAndSumScore
+      extends PTransform<PCollection<GameActionInfo>, PCollection<KV<String, Integer>>> {
+
+    private final String field;
+
+    ExtractAndSumScore(String field) {
+      this.field = field;
+    }
+
+    @Override
+    public PCollection<KV<String, Integer>> expand(PCollection<GameActionInfo> gameInfo) {
+
+      return gameInfo
+          .apply(
+              MapElements.into(
+                      TypeDescriptors.kvs(TypeDescriptors.strings(), TypeDescriptors.integers()))
+                  .via((GameActionInfo gInfo) -> KV.of(gInfo.getKey(field), gInfo.getScore())))
+          .apply(Sum.integersPerKey());
+    }
+  }
+  // [END DocInclude_USExtractXform]
+
+  /** Options supported by {@link UserScore}. */
+  public interface Options extends PipelineOptions {
+
+    @Description("Path to the data file(s) containing game data.")
+    /* The default maps to two large Google Cloud Storage files (each ~12GB) holding two subsequent
+    day's worth (roughly) of data.
+
+    Note: You may want to use a small sample dataset to test it locally/quickly : gs://apache-beam-samples/game/small/gaming_data.csv
+    You can also download it via the command line gsutil cp gs://apache-beam-samples/game/small/gaming_data.csv ./destination_folder/gaming_data.csv */
+    @Default.String("gs://apache-beam-samples/game/gaming_data*.csv")
+    String getInput();
+
+    void setInput(String value);
+
+    // Set this required option to specify where to write the output.
+    @Description("Path of the file to write to.")
+    @Validation.Required
+    String getOutput();
+
+    void setOutput(String value);
+  }
+
+  /**
+   * Create a map of information that describes how to write pipeline output to text. This map is
+   * passed to the {@link WriteToText} constructor to write user score sums.
+   */
+  protected static Map<String, WriteToText.FieldFn<KV<String, Integer>>> configureOutput() {
+    Map<String, WriteToText.FieldFn<KV<String, Integer>>> config = new HashMap<>();
+    config.put("user", (c, w) -> c.element().getKey());
+    config.put("total_score", (c, w) -> c.element().getValue());
+    return config;
+  }
+
+  /** Run a batch pipeline. */
+  // [START DocInclude_USMain]
+  public static void main(String[] args) throws Exception {
+    // Begin constructing a pipeline configured by commandline flags.
+    Options options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
+    Pipeline pipeline = Pipeline.create(options);
+
+    // Read events from a text file and parse them.
+    pipeline
+        .apply(TextIO.read().from(options.getInput()))
+        .apply("ParseGameEvent", ParDo.of(new ParseEventFn()))
+        // Extract and sum username/score pairs from the event data.
+        .apply("ExtractUserScore", new ExtractAndSumScore("user"))
+        .apply(
+            "WriteUserScoreSums", new WriteToText<>(options.getOutput(), configureOutput(), false));
+
+    // Run the batch pipeline.
+    pipeline.run().waitUntilFinish();
+  }
+  // [END DocInclude_USMain]
+}

--- a/buildSrc/src/archetype-resources/src/main/java/complete/game/injector/Injector.java
+++ b/buildSrc/src/archetype-resources/src/main/java/complete/game/injector/Injector.java
@@ -1,0 +1,443 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.complete.game.injector;
+
+import com.google.api.services.pubsub.Pubsub;
+import com.google.api.services.pubsub.model.PublishRequest;
+import com.google.api.services.pubsub.model.PubsubMessage;
+import java.io.BufferedOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import ${package}.complete.game.utils.GameConstants;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
+
+/**
+ * This is a generator that simulates usage data from a mobile game, and either publishes the data
+ * to a pubsub topic or writes it to a file.
+ *
+ * <p>The general model used by the generator is the following. There is a set of teams with team
+ * members. Each member is scoring points for their team. After some period, a team will dissolve
+ * and a new one will be created in its place. There is also a set of 'Robots', or spammer users.
+ * They hop from team to team. The robots are set to have a higher 'click rate' (generate more
+ * events) than the regular team members.
+ *
+ * <p>Each generated line of data has the following form:
+ * username,teamname,score,timestamp_in_ms,readable_time e.g.:
+ * user2_AsparagusPig,AsparagusPig,10,1445230923951,2015-11-02 09:09:28.224
+ *
+ * <p>The Injector writes either to a PubSub topic, or a file. It will use the PubSub topic if
+ * specified. It takes the following arguments: {@code Injector project-name (topic-name|none)
+ * (filename|none)}.
+ *
+ * <p>To run the Injector in the mode where it publishes to PubSub, you will need to authenticate
+ * locally using project-based service account credentials to avoid running over PubSub quota. See
+ * https://developers.google.com/identity/protocols/application-default-credentials for more
+ * information on using service account credentials. Set the GOOGLE_APPLICATION_CREDENTIALS
+ * environment variable to point to your downloaded service account credentials before starting the
+ * program, e.g.: {@code export GOOGLE_APPLICATION_CREDENTIALS=/path/to/your/credentials-key.json}.
+ * If you do not do this, then your injector will only run for a few minutes on your 'user account'
+ * credentials before you will start to see quota error messages like: "Request throttled due to
+ * user QPS limit being reached", and see this exception:
+ * ".com.google.api.client.googleapis.json.GoogleJsonResponseException: 429 Too Many Requests". Once
+ * you've set up your credentials, run the Injector like this":
+ *
+ * <pre>{@code
+ * Injector <project-name> <topic-name> none
+ * }</pre>
+ *
+ * The pubsub topic will be created if it does not exist.
+ *
+ * <p>To run the injector in write-to-file-mode, set the topic name to "none" and specify the
+ * filename:
+ *
+ * <pre>{@code
+ * Injector <project-name> none <filename>
+ * }</pre>
+ */
+class Injector {
+  private static Pubsub pubsub;
+  private static Random random = new Random();
+  private static String topic;
+  private static String project;
+
+  // QPS ranges from 800 to 1000.
+  private static final int MIN_QPS = 800;
+  private static final int QPS_RANGE = 200;
+  // How long to sleep, in ms, between creation of the threads that make API requests to PubSub.
+  private static final int THREAD_SLEEP_MS = 500;
+
+  // Lists used to generate random team names.
+  // If COLORS is changed, please also make changes in
+  // release/src/main/groovy/MobileGamingCommands.COLORS
+  private static final ArrayList<String> COLORS =
+      new ArrayList<>(
+          Arrays.asList(
+              "Magenta",
+              "AliceBlue",
+              "Almond",
+              "Amaranth",
+              "Amber",
+              "Amethyst",
+              "AndroidGreen",
+              "AntiqueBrass",
+              "Fuchsia",
+              "Ruby",
+              "AppleGreen",
+              "Apricot",
+              "Aqua",
+              "ArmyGreen",
+              "Asparagus",
+              "Auburn",
+              "Azure",
+              "Banana",
+              "Beige",
+              "Bisque",
+              "BarnRed",
+              "BattleshipGrey"));
+
+  private static final ArrayList<String> ANIMALS =
+      new ArrayList<>(
+          Arrays.asList(
+              "Echidna",
+              "Koala",
+              "Wombat",
+              "Marmot",
+              "Quokka",
+              "Kangaroo",
+              "Dingo",
+              "Numbat",
+              "Emu",
+              "Wallaby",
+              "CaneToad",
+              "Bilby",
+              "Possum",
+              "Cassowary",
+              "Kookaburra",
+              "Platypus",
+              "Bandicoot",
+              "Cockatoo",
+              "Antechinus"));
+
+  // The list of live teams.
+  private static ArrayList<TeamInfo> liveTeams = new ArrayList<>();
+
+  // The total number of robots in the system.
+  private static final int NUM_ROBOTS = 20;
+  // Determines the chance that a team will have a robot team member.
+  private static final int ROBOT_PROBABILITY = 3;
+  private static final int NUM_LIVE_TEAMS = 15;
+  private static final int BASE_MEMBERS_PER_TEAM = 5;
+  private static final int MEMBERS_PER_TEAM = 15;
+  private static final int MAX_SCORE = 20;
+  private static final int LATE_DATA_RATE = 5 * 60 * 2; // Every 10 minutes
+  private static final int BASE_DELAY_IN_MILLIS = 5 * 60 * 1000; // 5-10 minute delay
+  private static final int FUZZY_DELAY_IN_MILLIS = 5 * 60 * 1000;
+
+  // The minimum time a 'team' can live.
+  private static final int BASE_TEAM_EXPIRATION_TIME_IN_MINS = 20;
+  private static final int TEAM_EXPIRATION_TIME_IN_MINS = 20;
+
+  /**
+   * A class for holding team info: the name of the team, when it started, and the current team
+   * members. Teams may but need not include one robot team member.
+   */
+  private static class TeamInfo {
+    String teamName;
+    long startTimeInMillis;
+    int expirationPeriod;
+    // The team might but need not include 1 robot. Will be non-null if so.
+    String robot;
+    int numMembers;
+
+    private TeamInfo(String teamName, long startTimeInMillis, String robot) {
+      this.teamName = teamName;
+      this.startTimeInMillis = startTimeInMillis;
+      // How long until this team is dissolved.
+      this.expirationPeriod =
+          random.nextInt(TEAM_EXPIRATION_TIME_IN_MINS) + BASE_TEAM_EXPIRATION_TIME_IN_MINS;
+      this.robot = robot;
+      // Determine the number of team members.
+      numMembers = random.nextInt(MEMBERS_PER_TEAM) + BASE_MEMBERS_PER_TEAM;
+    }
+
+    String getTeamName() {
+      return teamName;
+    }
+
+    String getRobot() {
+      return robot;
+    }
+
+    long getStartTimeInMillis() {
+      return startTimeInMillis;
+    }
+
+    long getEndTimeInMillis() {
+      return startTimeInMillis + (expirationPeriod * 60L * 1000L);
+    }
+
+    String getRandomUser() {
+      int userNum = random.nextInt(numMembers);
+      return "user" + userNum + "_" + teamName;
+    }
+
+    int numMembers() {
+      return numMembers;
+    }
+
+    @Override
+    public String toString() {
+      return "("
+          + teamName
+          + ", num members: "
+          + numMembers()
+          + ", starting at: "
+          + startTimeInMillis
+          + ", expires in: "
+          + expirationPeriod
+          + ", robot: "
+          + robot
+          + ")";
+    }
+  }
+
+  /** Utility to grab a random element from an array of Strings. */
+  private static String randomElement(ArrayList<String> list) {
+    int index = random.nextInt(list.size());
+    return list.get(index);
+  }
+
+  /**
+   * Get and return a random team. If the selected team is too old w.r.t its expiration, remove it,
+   * replacing it with a new team.
+   */
+  private static TeamInfo randomTeam(ArrayList<TeamInfo> list) {
+    int index = random.nextInt(list.size());
+    TeamInfo team = list.get(index);
+    // If the selected team is expired, remove it and return a new team.
+    long currTime = System.currentTimeMillis();
+    if ((team.getEndTimeInMillis() < currTime) || team.numMembers() == 0) {
+      System.out.println("\nteam " + team + " is too old; replacing.");
+      System.out.println(
+          "start time: "
+              + team.getStartTimeInMillis()
+              + ", end time: "
+              + team.getEndTimeInMillis()
+              + ", current time:"
+              + currTime);
+      removeTeam(index);
+      // Add a new team in its stead.
+      return addLiveTeam();
+    } else {
+      return team;
+    }
+  }
+
+  /** Create and add a team. Possibly add a robot to the team. */
+  private static synchronized TeamInfo addLiveTeam() {
+    String teamName = randomElement(COLORS) + randomElement(ANIMALS);
+    String robot = null;
+    // Decide if we want to add a robot to the team.
+    if (random.nextInt(ROBOT_PROBABILITY) == 0) {
+      robot = "Robot-" + random.nextInt(NUM_ROBOTS);
+    }
+    // Create the new team.
+    TeamInfo newTeam = new TeamInfo(teamName, System.currentTimeMillis(), robot);
+    liveTeams.add(newTeam);
+    System.out.println("[+" + newTeam + "]");
+    return newTeam;
+  }
+
+  /** Remove a specific team. */
+  private static synchronized void removeTeam(int teamIndex) {
+    TeamInfo removedTeam = liveTeams.remove(teamIndex);
+    System.out.println("[-" + removedTeam + "]");
+  }
+
+  /** Generate a user gaming event. */
+  private static String generateEvent(Long currTime, int delayInMillis) {
+    TeamInfo team = randomTeam(liveTeams);
+    String teamName = team.getTeamName();
+    String user;
+    final int parseErrorRate = 900000;
+
+    String robot = team.getRobot();
+    // If the team has an associated robot team member...
+    if (robot != null) {
+      // Then use that robot for the message with some probability.
+      // Set this probability to higher than that used to select any of the 'regular' team
+      // members, so that if there is a robot on the team, it has a higher click rate.
+      if (random.nextInt(team.numMembers() / 2) == 0) {
+        user = robot;
+      } else {
+        user = team.getRandomUser();
+      }
+    } else { // No robot.
+      user = team.getRandomUser();
+    }
+    String event = user + "," + teamName + "," + random.nextInt(MAX_SCORE);
+    // Randomly introduce occasional parse errors.
+    if (random.nextInt(parseErrorRate) == 0) {
+      System.out.println("Introducing a parse error.");
+      event = "THIS LINE REPRESENTS CORRUPT DATA AND WILL CAUSE A PARSE ERROR";
+    }
+    return addTimeInfoToEvent(event, currTime, delayInMillis);
+  }
+
+  /** Add time info to a generated gaming event. */
+  private static String addTimeInfoToEvent(String message, Long currTime, int delayInMillis) {
+    String eventTimeString = Long.toString((currTime - delayInMillis) / 1000 * 1000);
+    // Add a (redundant) 'human-readable' date string to make the data semantics more clear.
+    String dateString = GameConstants.DATE_TIME_FORMATTER.print(currTime);
+    message = message + "," + eventTimeString + "," + dateString;
+    return message;
+  }
+
+  /**
+   * Publish 'numMessages' arbitrary events from live users with the provided delay, to a PubSub
+   * topic.
+   */
+  public static void publishData(int numMessages, int delayInMillis) throws IOException {
+    List<PubsubMessage> pubsubMessages = new ArrayList<>();
+
+    for (int i = 0; i < Math.max(1, numMessages); i++) {
+      Long currTime = System.currentTimeMillis();
+      String message = generateEvent(currTime, delayInMillis);
+      PubsubMessage pubsubMessage = new PubsubMessage().encodeData(message.getBytes("UTF-8"));
+      pubsubMessage.setAttributes(
+          ImmutableMap.of(
+              GameConstants.TIMESTAMP_ATTRIBUTE,
+              Long.toString((currTime - delayInMillis) / 1000 * 1000)));
+      if (delayInMillis != 0) {
+        System.out.println(pubsubMessage.getAttributes());
+        System.out.println("late data for: " + message);
+      }
+      pubsubMessages.add(pubsubMessage);
+    }
+
+    PublishRequest publishRequest = new PublishRequest();
+    publishRequest.setMessages(pubsubMessages);
+    pubsub.projects().topics().publish(topic, publishRequest).execute();
+  }
+
+  /** Publish generated events to a file. */
+  public static void publishDataToFile(String fileName, int numMessages, int delayInMillis)
+      throws IOException {
+    PrintWriter out =
+        new PrintWriter(
+            new OutputStreamWriter(
+                new BufferedOutputStream(new FileOutputStream(fileName, true)), "UTF-8"));
+
+    try {
+      for (int i = 0; i < Math.max(1, numMessages); i++) {
+        Long currTime = System.currentTimeMillis();
+        String message = generateEvent(currTime, delayInMillis);
+        out.println(message);
+      }
+    } catch (Exception e) {
+      System.err.print("Error in writing generated events to file");
+      e.printStackTrace();
+    } finally {
+      out.flush();
+      out.close();
+    }
+  }
+
+  public static void main(String[] args) throws IOException, InterruptedException {
+    if (args.length < 3) {
+      System.out.println("Usage: Injector project-name (topic-name|none) (filename|none)");
+      System.exit(1);
+    }
+    boolean writeToFile = false;
+    boolean writeToPubsub = true;
+    project = args[0];
+    String topicName = args[1];
+    String fileName = args[2];
+    // The Injector writes either to a PubSub topic, or a file. It will use the PubSub topic if
+    // specified; otherwise, it will try to write to a file.
+    if ("none".equalsIgnoreCase(topicName)) {
+      writeToFile = true;
+      writeToPubsub = false;
+    }
+    if (writeToPubsub) {
+      // Create the PubSub client.
+      pubsub = InjectorUtils.getClient();
+      // Create the PubSub topic as necessary.
+      topic = InjectorUtils.getFullyQualifiedTopicName(project, topicName);
+      InjectorUtils.createTopic(pubsub, topic);
+      System.out.println("Injecting to topic: " + topic);
+    } else {
+      if ("none".equalsIgnoreCase(fileName)) {
+        System.out.println("Filename not specified.");
+        System.exit(1);
+      }
+      System.out.println("Writing to file: " + fileName);
+    }
+    System.out.println("Starting Injector");
+
+    // Start off with some random live teams.
+    while (liveTeams.size() < NUM_LIVE_TEAMS) {
+      addLiveTeam();
+    }
+
+    // Publish messages at a rate determined by the QPS and Thread sleep settings.
+    for (int i = 0; true; i++) {
+      if (Thread.activeCount() > 10) {
+        System.err.println("I'm falling behind!");
+      }
+
+      // Decide if this should be a batch of late data.
+      final int numMessages;
+      final int delayInMillis;
+      if (i % LATE_DATA_RATE == 0) {
+        // Insert delayed data for one user (one message only)
+        delayInMillis = BASE_DELAY_IN_MILLIS + random.nextInt(FUZZY_DELAY_IN_MILLIS);
+        numMessages = 1;
+        System.out.println("DELAY(" + delayInMillis + ", " + numMessages + ")");
+      } else {
+        System.out.print(".");
+        delayInMillis = 0;
+        numMessages = MIN_QPS + random.nextInt(QPS_RANGE);
+      }
+
+      if (writeToFile) { // Won't use threading for the file write.
+        publishDataToFile(fileName, numMessages, delayInMillis);
+      } else { // Write to PubSub.
+        // Start a thread to inject some data.
+        new Thread(
+                () -> {
+                  try {
+                    publishData(numMessages, delayInMillis);
+                  } catch (IOException e) {
+                    System.err.println(e);
+                  }
+                })
+            .start();
+      }
+
+      // Wait before creating another injector thread.
+      Thread.sleep(THREAD_SLEEP_MS);
+    }
+  }
+}

--- a/buildSrc/src/archetype-resources/src/main/java/complete/game/injector/InjectorUtils.java
+++ b/buildSrc/src/archetype-resources/src/main/java/complete/game/injector/InjectorUtils.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.complete.game.injector;
+
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.googleapis.util.Utils;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.HttpStatusCodes;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.services.pubsub.Pubsub;
+import com.google.api.services.pubsub.PubsubScopes;
+import com.google.api.services.pubsub.model.Topic;
+import java.io.IOException;
+
+class InjectorUtils {
+
+  private static final String APP_NAME = "injector";
+
+  /** Builds a new Pubsub client and returns it. */
+  public static Pubsub getClient(final HttpTransport httpTransport, final JsonFactory jsonFactory)
+      throws IOException {
+    checkNotNull(httpTransport);
+    checkNotNull(jsonFactory);
+    GoogleCredential credential =
+        GoogleCredential.getApplicationDefault(httpTransport, jsonFactory);
+    if (credential.createScopedRequired()) {
+      credential = credential.createScoped(PubsubScopes.all());
+    }
+    if (credential.getClientAuthentication() != null) {
+      System.out.println(
+          "\n***Warning! You are not using service account credentials to "
+              + "authenticate.\nYou need to use service account credentials for this example,"
+              + "\nsince user-level credentials do not have enough pubsub quota,\nand so you will run "
+              + "out of PubSub quota very quickly.\nSee "
+              + "https://developers.google.com/identity/protocols/application-default-credentials.");
+      System.exit(1);
+    }
+    HttpRequestInitializer initializer = new RetryHttpInitializerWrapper(credential);
+    return new Pubsub.Builder(httpTransport, jsonFactory, initializer)
+        .setApplicationName(APP_NAME)
+        .build();
+  }
+
+  /** Builds a new Pubsub client with default HttpTransport and JsonFactory and returns it. */
+  public static Pubsub getClient() throws IOException {
+    return getClient(Utils.getDefaultTransport(), Utils.getDefaultJsonFactory());
+  }
+
+  /** Returns the fully qualified topic name for Pub/Sub. */
+  public static String getFullyQualifiedTopicName(final String project, final String topic) {
+    return String.format("projects/%s/topics/%s", project, topic);
+  }
+
+  /** Create a topic if it doesn't exist. */
+  public static void createTopic(Pubsub client, String fullTopicName) throws IOException {
+    System.out.println("fullTopicName " + fullTopicName);
+    try {
+      client.projects().topics().get(fullTopicName).execute();
+    } catch (GoogleJsonResponseException e) {
+      if (e.getStatusCode() == HttpStatusCodes.STATUS_CODE_NOT_FOUND) {
+        Topic topic = client.projects().topics().create(fullTopicName, new Topic()).execute();
+        System.out.printf("Topic %s was created.%n", topic.getName());
+      }
+    }
+  }
+}

--- a/buildSrc/src/archetype-resources/src/main/java/complete/game/injector/RetryHttpInitializerWrapper.java
+++ b/buildSrc/src/archetype-resources/src/main/java/complete/game/injector/RetryHttpInitializerWrapper.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.complete.game.injector;
+
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.http.HttpBackOffIOExceptionHandler;
+import com.google.api.client.http.HttpBackOffUnsuccessfulResponseHandler;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.HttpUnsuccessfulResponseHandler;
+import com.google.api.client.util.ExponentialBackOff;
+import com.google.api.client.util.Sleeper;
+import java.util.logging.Logger;
+
+/**
+ * RetryHttpInitializerWrapper will automatically retry upon RPC failures, preserving the
+ * auto-refresh behavior of the Google Credentials.
+ */
+public class RetryHttpInitializerWrapper implements HttpRequestInitializer {
+
+  /** A private logger. */
+  private static final Logger LOG = Logger.getLogger(RetryHttpInitializerWrapper.class.getName());
+
+  /** One minutes in miliseconds. */
+  private static final int ONEMINITUES = 60000;
+
+  /**
+   * Intercepts the request for filling in the "Authorization" header field, as well as recovering
+   * from certain unsuccessful error codes wherein the Credential must refresh its token for a
+   * retry.
+   */
+  private final Credential wrappedCredential;
+
+  /** A sleeper; you can replace it with a mock in your test. */
+  private final Sleeper sleeper;
+
+  /**
+   * A constructor.
+   *
+   * @param wrappedCredential Credential which will be wrapped and used for providing auth header.
+   */
+  public RetryHttpInitializerWrapper(final Credential wrappedCredential) {
+    this(wrappedCredential, Sleeper.DEFAULT);
+  }
+
+  /**
+   * A protected constructor only for testing.
+   *
+   * @param wrappedCredential Credential which will be wrapped and used for providing auth header.
+   * @param sleeper Sleeper for easy testing.
+   */
+  RetryHttpInitializerWrapper(final Credential wrappedCredential, final Sleeper sleeper) {
+    this.wrappedCredential = checkNotNull(wrappedCredential);
+    this.sleeper = sleeper;
+  }
+
+  /** Initializes the given request. */
+  @Override
+  public final void initialize(final HttpRequest request) {
+    request.setReadTimeout(2 * ONEMINITUES); // 2 minutes read timeout
+    final HttpUnsuccessfulResponseHandler backoffHandler =
+        new HttpBackOffUnsuccessfulResponseHandler(new ExponentialBackOff()).setSleeper(sleeper);
+    request.setInterceptor(wrappedCredential);
+    request.setUnsuccessfulResponseHandler(
+        (request1, response, supportsRetry) -> {
+          if (wrappedCredential.handleResponse(request1, response, supportsRetry)) {
+            // If credential decides it can handle it, the return code or message indicated
+            // something specific to authentication, and no backoff is desired.
+            return true;
+          } else if (backoffHandler.handleResponse(request1, response, supportsRetry)) {
+            // Otherwise, we defer to the judgement of our internal backoff handler.
+            LOG.info("Retrying " + request1.getUrl().toString());
+            return true;
+          } else {
+            return false;
+          }
+        });
+    request.setIOExceptionHandler(
+        new HttpBackOffIOExceptionHandler(new ExponentialBackOff()).setSleeper(sleeper));
+  }
+}

--- a/buildSrc/src/archetype-resources/src/main/java/complete/game/utils/GameConstants.java
+++ b/buildSrc/src/archetype-resources/src/main/java/complete/game/utils/GameConstants.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.complete.game.utils;
+
+import java.util.TimeZone;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
+/** Shared constants between game series classes. */
+public class GameConstants {
+
+  public static final String TIMESTAMP_ATTRIBUTE = "timestamp_ms";
+
+  public static final DateTimeFormatter DATE_TIME_FORMATTER =
+      DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSS")
+          .withZone(DateTimeZone.forTimeZone(TimeZone.getTimeZone("America/Los_Angeles")));
+}

--- a/buildSrc/src/archetype-resources/src/main/java/complete/game/utils/WriteToBigQuery.java
+++ b/buildSrc/src/archetype-resources/src/main/java/complete/game/utils/WriteToBigQuery.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.complete.game.utils;
+
+import com.google.api.services.bigquery.model.TableFieldSchema;
+import com.google.api.services.bigquery.model.TableReference;
+import com.google.api.services.bigquery.model.TableRow;
+import com.google.api.services.bigquery.model.TableSchema;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.CreateDisposition;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.WriteDisposition;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PDone;
+
+/**
+ * Generate, format, and write BigQuery table row information. Use provided information about the
+ * field names and types, as well as lambda functions that describe how to generate their values.
+ */
+public class WriteToBigQuery<InputT> extends PTransform<PCollection<InputT>, PDone> {
+
+  protected String projectId;
+  protected String datasetId;
+  protected String tableName;
+  protected Map<String, FieldInfo<InputT>> fieldInfo;
+
+  public WriteToBigQuery() {}
+
+  public WriteToBigQuery(
+      String projectId,
+      String datasetId,
+      String tableName,
+      Map<String, FieldInfo<InputT>> fieldInfo) {
+    this.projectId = projectId;
+    this.datasetId = datasetId;
+    this.tableName = tableName;
+    this.fieldInfo = fieldInfo;
+  }
+
+  /**
+   * A {@link Serializable} function from a {@link DoFn.ProcessContext} and {@link BoundedWindow} to
+   * the value for that field.
+   */
+  public interface FieldFn<InputT> extends Serializable {
+    Object apply(DoFn<InputT, TableRow>.ProcessContext context, BoundedWindow window);
+  }
+
+  /** Define a class to hold information about output table field definitions. */
+  public static class FieldInfo<InputT> implements Serializable {
+    // The BigQuery 'type' of the field
+    private String fieldType;
+    // A lambda function to generate the field value
+    private FieldFn<InputT> fieldFn;
+
+    public FieldInfo(String fieldType, FieldFn<InputT> fieldFn) {
+      this.fieldType = fieldType;
+      this.fieldFn = fieldFn;
+    }
+
+    String getFieldType() {
+      return this.fieldType;
+    }
+
+    FieldFn<InputT> getFieldFn() {
+      return this.fieldFn;
+    }
+  }
+
+  /** Convert each key/score pair into a BigQuery TableRow as specified by fieldFn. */
+  protected class BuildRowFn extends DoFn<InputT, TableRow> {
+
+    @ProcessElement
+    public void processElement(ProcessContext c, BoundedWindow window) {
+
+      TableRow row = new TableRow();
+      for (Map.Entry<String, FieldInfo<InputT>> entry : fieldInfo.entrySet()) {
+        String key = entry.getKey();
+        FieldInfo<InputT> fcnInfo = entry.getValue();
+        FieldFn<InputT> fcn = fcnInfo.getFieldFn();
+        row.set(key, fcn.apply(c, window));
+      }
+      c.output(row);
+    }
+  }
+
+  /** Build the output table schema. */
+  protected TableSchema getSchema() {
+    List<TableFieldSchema> fields = new ArrayList<>();
+    for (Map.Entry<String, FieldInfo<InputT>> entry : fieldInfo.entrySet()) {
+      String key = entry.getKey();
+      FieldInfo<InputT> fcnInfo = entry.getValue();
+      String bqType = fcnInfo.getFieldType();
+      fields.add(new TableFieldSchema().setName(key).setType(bqType));
+    }
+    return new TableSchema().setFields(fields);
+  }
+
+  @Override
+  public PDone expand(PCollection<InputT> teamAndScore) {
+    teamAndScore
+        .apply("ConvertToRow", ParDo.of(new BuildRowFn()))
+        .apply(
+            BigQueryIO.writeTableRows()
+                .to(getTable(projectId, datasetId, tableName))
+                .withSchema(getSchema())
+                .withCreateDisposition(CreateDisposition.CREATE_IF_NEEDED)
+                .withWriteDisposition(WriteDisposition.WRITE_APPEND));
+    return PDone.in(teamAndScore.getPipeline());
+  }
+
+  /** Utility to construct an output table reference. */
+  static TableReference getTable(String projectId, String datasetId, String tableName) {
+    TableReference table = new TableReference();
+    table.setDatasetId(datasetId);
+    table.setProjectId(projectId);
+    table.setTableId(tableName);
+    return table;
+  }
+}

--- a/buildSrc/src/archetype-resources/src/main/java/complete/game/utils/WriteToText.java
+++ b/buildSrc/src/archetype-resources/src/main/java/complete/game/utils/WriteToText.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.complete.game.utils;
+
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.stream.Collectors;
+import org.apache.beam.sdk.io.FileBasedSink;
+import org.apache.beam.sdk.io.FileBasedSink.FilenamePolicy;
+import org.apache.beam.sdk.io.FileBasedSink.OutputFileHints;
+import org.apache.beam.sdk.io.TextIO;
+import org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions;
+import org.apache.beam.sdk.io.fs.ResourceId;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
+import org.apache.beam.sdk.transforms.windowing.PaneInfo;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PDone;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
+/**
+ * Generate, format, and write rows. Use provided information about the field names and types, as
+ * well as lambda functions that describe how to generate their values.
+ */
+public class WriteToText<InputT> extends PTransform<PCollection<InputT>, PDone> {
+
+  private static final DateTimeFormatter formatter =
+      DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSS")
+          .withZone(DateTimeZone.forTimeZone(TimeZone.getTimeZone("America/Los_Angeles")));
+
+  protected String filenamePrefix;
+  protected Map<String, FieldFn<InputT>> fieldFn;
+  protected boolean windowed;
+
+  public WriteToText() {}
+
+  public WriteToText(
+      String filenamePrefix, Map<String, FieldFn<InputT>> fieldFn, boolean windowed) {
+    this.filenamePrefix = filenamePrefix;
+    this.fieldFn = fieldFn;
+    this.windowed = windowed;
+  }
+
+  /**
+   * A {@link Serializable} function from a {@link DoFn.ProcessContext} and {@link BoundedWindow} to
+   * the value for that field.
+   */
+  public interface FieldFn<InputT> extends Serializable {
+    Object apply(DoFn<InputT, String>.ProcessContext context, BoundedWindow window);
+  }
+
+  /** Convert each key/score pair into a row as specified by fieldFn. */
+  protected class BuildRowFn extends DoFn<InputT, String> {
+
+    @ProcessElement
+    public void processElement(ProcessContext c, BoundedWindow window) {
+      List<String> fields = new ArrayList<>();
+      for (Map.Entry<String, FieldFn<InputT>> entry : fieldFn.entrySet()) {
+        String key = entry.getKey();
+        FieldFn<InputT> fcn = entry.getValue();
+        fields.add(key + ": " + fcn.apply(c, window));
+      }
+      String result = fields.stream().collect(Collectors.joining(", "));
+      c.output(result);
+    }
+  }
+
+  /**
+   * A {@link DoFn} that writes elements to files with names deterministically derived from the
+   * lower and upper bounds of their key (an {@link IntervalWindow}).
+   */
+  protected static class WriteOneFilePerWindow extends PTransform<PCollection<String>, PDone> {
+
+    private final String filenamePrefix;
+
+    public WriteOneFilePerWindow(String filenamePrefix) {
+      this.filenamePrefix = filenamePrefix;
+    }
+
+    @Override
+    public PDone expand(PCollection<String> input) {
+      // Verify that the input has a compatible window type.
+      checkArgument(
+          input.getWindowingStrategy().getWindowFn().windowCoder() == IntervalWindow.getCoder());
+
+      ResourceId resource = FileBasedSink.convertToFileResourceIfPossible(filenamePrefix);
+
+      return input.apply(
+          TextIO.write()
+              .to(new PerWindowFiles(resource))
+              .withTempDirectory(resource.getCurrentDirectory())
+              .withWindowedWrites()
+              .withNumShards(3));
+    }
+  }
+
+  /**
+   * A {@link FilenamePolicy} produces a base file name for a write based on metadata about the data
+   * being written. This always includes the shard number and the total number of shards. For
+   * windowed writes, it also includes the window and pane index (a sequence number assigned to each
+   * trigger firing).
+   */
+  protected static class PerWindowFiles extends FilenamePolicy {
+
+    private final ResourceId prefix;
+
+    public PerWindowFiles(ResourceId prefix) {
+      this.prefix = prefix;
+    }
+
+    public String filenamePrefixForWindow(IntervalWindow window) {
+      String filePrefix = prefix.isDirectory() ? "" : prefix.getFilename();
+      return String.format(
+          "%s-%s-%s", filePrefix, formatter.print(window.start()), formatter.print(window.end()));
+    }
+
+    @Override
+    public ResourceId windowedFilename(
+        int shardNumber,
+        int numShards,
+        BoundedWindow window,
+        PaneInfo paneInfo,
+        OutputFileHints outputFileHints) {
+      IntervalWindow intervalWindow = (IntervalWindow) window;
+      String filename =
+          String.format(
+              "%s-%s-of-%s%s",
+              filenamePrefixForWindow(intervalWindow),
+              shardNumber,
+              numShards,
+              outputFileHints.getSuggestedFilenameSuffix());
+      return prefix.getCurrentDirectory().resolve(filename, StandardResolveOptions.RESOLVE_FILE);
+    }
+
+    @Override
+    public ResourceId unwindowedFilename(
+        int shardNumber, int numShards, OutputFileHints outputFileHints) {
+      throw new UnsupportedOperationException("Unsupported.");
+    }
+  }
+
+  @Override
+  public PDone expand(PCollection<InputT> teamAndScore) {
+    if (windowed) {
+      teamAndScore
+          .apply("ConvertToRow", ParDo.of(new BuildRowFn()))
+          .apply(new WriteToText.WriteOneFilePerWindow(filenamePrefix));
+    } else {
+      teamAndScore
+          .apply("ConvertToRow", ParDo.of(new BuildRowFn()))
+          .apply(TextIO.write().to(filenamePrefix));
+    }
+    return PDone.in(teamAndScore.getPipeline());
+  }
+}

--- a/buildSrc/src/archetype-resources/src/main/java/complete/game/utils/WriteWindowedToBigQuery.java
+++ b/buildSrc/src/archetype-resources/src/main/java/complete/game/utils/WriteWindowedToBigQuery.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.complete.game.utils;
+
+import com.google.api.services.bigquery.model.TableRow;
+import java.util.Map;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.CreateDisposition;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.WriteDisposition;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PDone;
+
+/**
+ * Generate, format, and write BigQuery table row information. Subclasses {@link WriteToBigQuery} to
+ * require windowing; so this subclass may be used for writes that require access to the context's
+ * window information.
+ */
+public class WriteWindowedToBigQuery<T> extends WriteToBigQuery<T> {
+
+  public WriteWindowedToBigQuery(
+      String projectId, String datasetId, String tableName, Map<String, FieldInfo<T>> fieldInfo) {
+    super(projectId, datasetId, tableName, fieldInfo);
+  }
+
+  /** Convert each key/score pair into a BigQuery TableRow. */
+  protected class BuildRowFn extends DoFn<T, TableRow> {
+    @ProcessElement
+    public void processElement(ProcessContext c, BoundedWindow window) {
+
+      TableRow row = new TableRow();
+      for (Map.Entry<String, FieldInfo<T>> entry : fieldInfo.entrySet()) {
+        String key = entry.getKey();
+        FieldInfo<T> fcnInfo = entry.getValue();
+        row.set(key, fcnInfo.getFieldFn().apply(c, window));
+      }
+      c.output(row);
+    }
+  }
+
+  @Override
+  public PDone expand(PCollection<T> teamAndScore) {
+    teamAndScore
+        .apply("ConvertToRow", ParDo.of(new BuildRowFn()))
+        .apply(
+            BigQueryIO.writeTableRows()
+                .to(getTable(projectId, datasetId, tableName))
+                .withSchema(getSchema())
+                .withCreateDisposition(CreateDisposition.CREATE_IF_NEEDED)
+                .withWriteDisposition(WriteDisposition.WRITE_APPEND));
+    return PDone.in(teamAndScore.getPipeline());
+  }
+}

--- a/buildSrc/src/archetype-resources/src/main/java/subprocess/Echo.cc
+++ b/buildSrc/src/archetype-resources/src/main/java/subprocess/Echo.cc
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// 'Hello World!' program
+
+#include <iostream>
+#include <fstream>
+
+int main(int argc, char* argv[])
+{
+    if(argc < 3){
+        std::cerr << "No parameter sent, must send the return file location and a statement to echo" << '\n';
+        return 1;
+    }
+    std::string retFile = argv[1];
+    std::string word = argv[2];
+    std::ofstream myfile;
+    myfile.open (retFile);
+    myfile << word;
+    myfile.close();
+    return 0;
+}

--- a/buildSrc/src/archetype-resources/src/main/java/subprocess/EchoAgain.cc
+++ b/buildSrc/src/archetype-resources/src/main/java/subprocess/EchoAgain.cc
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// 'Hello World!' program, just echos what was sent to it.
+
+#include <iostream>
+#include <fstream>
+
+int main(int argc, char* argv[])
+{
+    if(argc < 3){
+        std::cerr << "No parameter sent, must send the return file location and a statement to echo" << '\n';
+        return 1;
+    }
+    std::string retFile = argv[1];
+    std::string word = argv[2];
+    std::ofstream myfile;
+    myfile.open (retFile);
+    myfile << "You again? Well ok, here is your word again." << word ;
+    myfile.close();
+    return 0;
+}

--- a/buildSrc/src/archetype-resources/src/main/java/subprocess/ExampleEchoPipeline.java
+++ b/buildSrc/src/archetype-resources/src/main/java/subprocess/ExampleEchoPipeline.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.subprocess;
+
+import java.util.ArrayList;
+import java.util.List;
+import ${package}.subprocess.configuration.SubProcessConfiguration;
+import ${package}.subprocess.kernel.SubProcessCommandLineArgs;
+import ${package}.subprocess.kernel.SubProcessCommandLineArgs.Command;
+import ${package}.subprocess.kernel.SubProcessKernel;
+import ${package}.subprocess.utils.CallingSubProcessUtils;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.KV;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * In this example batch pipeline we will invoke a simple Echo C++ library within a DoFn The sample
+ * makes use of a ExternalLibraryDoFn class which abstracts the setup and processing of the
+ * executable, logs and results. For this example we are using commands passed to the library based
+ * on ordinal position but for a production system you should use a mechanism like ProtoBuffers with
+ * Base64 encoding to pass the parameters to the library To test this example you will need to build
+ * the files Echo.cc and EchoAgain.cc in a linux env matching the runner that you are using (using
+ * g++ with static option). Once built copy them to the SourcePath defined in {@link
+ * SubProcessPipelineOptions}
+ */
+public class ExampleEchoPipeline {
+  static final Logger LOG = LoggerFactory.getLogger(ExampleEchoPipeline.class);
+
+  public static void main(String[] args) throws Exception {
+
+    // Read in the options for the pipeline
+    SubProcessPipelineOptions options =
+        PipelineOptionsFactory.fromArgs(args).withValidation().as(SubProcessPipelineOptions.class);
+
+    Pipeline p = Pipeline.create(options);
+
+    // Setup the Configuration option used with all transforms
+    SubProcessConfiguration configuration = options.getSubProcessConfiguration();
+
+    // Create some sample data to be fed to our c++ Echo library
+    List<KV<String, String>> sampleData = new ArrayList<>();
+    for (int i = 0; i < 10000; i++) {
+      String str = String.valueOf(i);
+      sampleData.add(KV.of(str, str));
+    }
+
+    // Define the pipeline which is two transforms echoing the inputs out to Logs
+    p.apply(Create.of(sampleData))
+        .apply("Echo inputs round 1", ParDo.of(new EchoInputDoFn(configuration, "Echo")))
+        .apply("Echo inputs round 2", ParDo.of(new EchoInputDoFn(configuration, "EchoAgain")));
+
+    p.run();
+  }
+
+  /** Simple DoFn that echos the element, used as an example of running a C++ library. */
+  @SuppressWarnings("serial")
+  public static class EchoInputDoFn extends DoFn<KV<String, String>, KV<String, String>> {
+
+    static final Logger LOG = LoggerFactory.getLogger(EchoInputDoFn.class);
+
+    private SubProcessConfiguration configuration;
+    private String binaryName;
+
+    public EchoInputDoFn(SubProcessConfiguration configuration, String binary) {
+      // Pass in configuration information the name of the filename of the sub-process and the level
+      // of concurrency
+      this.configuration = configuration;
+      this.binaryName = binary;
+    }
+
+    @Setup
+    public void setUp() throws Exception {
+      CallingSubProcessUtils.setUp(configuration, binaryName);
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext c) throws Exception {
+      try {
+        // Our Library takes a single command in position 0 which it will echo back in the result
+        SubProcessCommandLineArgs commands = new SubProcessCommandLineArgs();
+        Command command = new Command(0, String.valueOf(c.element().getValue()));
+        commands.putCommand(command);
+
+        // The ProcessingKernel deals with the execution of the process
+        SubProcessKernel kernel = new SubProcessKernel(configuration, binaryName);
+
+        // Run the command and work through the results
+        List<String> results = kernel.exec(commands);
+        for (String s : results) {
+          c.output(KV.of(c.element().getKey(), s));
+        }
+      } catch (Exception ex) {
+        LOG.error("Error processing element ", ex);
+        throw ex;
+      }
+    }
+  }
+
+  private static String getTestShellEcho() {
+    return "#!/bin/sh\n" + "filename=$1;\n" + "echo $2 >> $filename;";
+  }
+
+  private static String getTestShellEchoAgain() {
+    return "#!/bin/sh\n"
+        + "filename=$1;\n"
+        + "echo \"You again? Well ok, here is your word again.\" >> $2 >> $filename;";
+  }
+}

--- a/buildSrc/src/archetype-resources/src/main/java/subprocess/SubProcessPipelineOptions.java
+++ b/buildSrc/src/archetype-resources/src/main/java/subprocess/SubProcessPipelineOptions.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.subprocess;
+
+import ${package}.subprocess.configuration.SubProcessConfiguration;
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.DefaultValueFactory;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.Validation.Required;
+
+/** Options for running a sub process within a DoFn. */
+public interface SubProcessPipelineOptions extends PipelineOptions {
+
+  @Description("Source GCS directory where the C++ library is located gs://bucket/tests")
+  @Required
+  String getSourcePath();
+
+  void setSourcePath(String sourcePath);
+
+  @Description("Working directory for the process I/O")
+  @Default.String("/tmp/grid_working_files")
+  String getWorkerPath();
+
+  void setWorkerPath(String workerPath);
+
+  @Description("The maximum time to wait for the sub-process to complete")
+  @Default.Integer(3600)
+  Integer getWaitTime();
+
+  void setWaitTime(Integer waitTime);
+
+  @Description("As sub-processes can be heavy weight define the level of concurrency level")
+  @Required
+  Integer getConcurrency();
+
+  void setConcurrency(Integer concurrency);
+
+  @Description("Should log files only be uploaded if error.")
+  @Default.Boolean(true)
+  Boolean getOnlyUpLoadLogsOnError();
+
+  void setOnlyUpLoadLogsOnError(Boolean onlyUpLoadLogsOnError);
+
+  @Default.InstanceFactory(SubProcessConfigurationFactory.class)
+  SubProcessConfiguration getSubProcessConfiguration();
+
+  void setSubProcessConfiguration(SubProcessConfiguration configuration);
+
+  /** Confirm Configuration and return a configuration object used in pipeline. */
+  class SubProcessConfigurationFactory implements DefaultValueFactory<SubProcessConfiguration> {
+    @Override
+    public SubProcessConfiguration create(PipelineOptions options) {
+
+      SubProcessPipelineOptions subProcessPipelineOptions = (SubProcessPipelineOptions) options;
+
+      SubProcessConfiguration configuration = new SubProcessConfiguration();
+
+      if (subProcessPipelineOptions.getSourcePath() == null) {
+        throw new IllegalStateException("Source path must be set");
+      }
+      if (subProcessPipelineOptions.getConcurrency() == null
+          || subProcessPipelineOptions.getConcurrency() == 0) {
+        throw new IllegalStateException("Concurrency must be set and be > 0");
+      }
+      configuration.setSourcePath(subProcessPipelineOptions.getSourcePath());
+      configuration.setWorkerPath(subProcessPipelineOptions.getWorkerPath());
+      configuration.setWaitTime(subProcessPipelineOptions.getWaitTime());
+      configuration.setOnlyUpLoadLogsOnError(subProcessPipelineOptions.getOnlyUpLoadLogsOnError());
+      configuration.concurrency = subProcessPipelineOptions.getConcurrency();
+
+      return configuration;
+    }
+  }
+}

--- a/buildSrc/src/archetype-resources/src/main/java/subprocess/configuration/SubProcessConfiguration.java
+++ b/buildSrc/src/archetype-resources/src/main/java/subprocess/configuration/SubProcessConfiguration.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.subprocess.configuration;
+
+import java.io.Serializable;
+
+/**
+ * Configuration file used to setup the Process kernel for execution of the external library Values
+ * are copied from the Options to all them to be Serializable.
+ */
+@SuppressWarnings("serial")
+public class SubProcessConfiguration implements Serializable {
+
+  // Source GCS directory where the C++ library is located gs://bucket/tests
+  public String sourcePath;
+
+  // Working directory for the process I/O
+  public String workerPath;
+
+  // The maximum time to wait for the sub-process to complete
+  public Integer waitTime;
+
+  // "As sub-processes can be heavy weight match the concurrency level to num cores on the machines"
+  public Integer concurrency;
+
+  // Should log files only be uploaded if error
+  public Boolean onlyUpLoadLogsOnError;
+
+  public Boolean getOnlyUpLoadLogsOnError() {
+    return onlyUpLoadLogsOnError;
+  }
+
+  public void setOnlyUpLoadLogsOnError(Boolean onlyUpLoadLogsOnError) {
+    this.onlyUpLoadLogsOnError = onlyUpLoadLogsOnError;
+  }
+
+  public String getSourcePath() {
+    return sourcePath;
+  }
+
+  public void setSourcePath(String sourcePath) {
+    this.sourcePath = sourcePath;
+  }
+
+  public String getWorkerPath() {
+    return workerPath;
+  }
+
+  public void setWorkerPath(String workerPath) {
+    this.workerPath = workerPath;
+  }
+
+  public Integer getWaitTime() {
+    return waitTime;
+  }
+
+  public void setWaitTime(Integer waitTime) {
+    this.waitTime = waitTime;
+  }
+
+  public Integer getConcurrency() {
+    return concurrency;
+  }
+
+  public void setConcurrency(Integer concurrency) {
+    this.concurrency = concurrency;
+  }
+}

--- a/buildSrc/src/archetype-resources/src/main/java/subprocess/kernel/SubProcessCommandLineArgs.java
+++ b/buildSrc/src/archetype-resources/src/main/java/subprocess/kernel/SubProcessCommandLineArgs.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.subprocess.kernel;
+
+import java.util.List;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
+
+/** Parameters to the sub-process, has tuple of ordinal position and the value. */
+public class SubProcessCommandLineArgs {
+
+  // Parameters to pass to the sub-process
+  private List<Command> parameters = Lists.newArrayList();
+
+  public void addCommand(Integer position, String value) {
+    parameters.add(new Command(position, value));
+  }
+
+  public void putCommand(Command command) {
+    parameters.add(command);
+  }
+
+  public List<Command> getParameters() {
+    return parameters;
+  }
+
+  /** Class used to store the SubProcces parameters. */
+  public static class Command {
+
+    // The ordinal position of the command to pass to the sub-process
+    int ordinalPosition;
+    String value;
+
+    @SuppressWarnings("unused")
+    private Command() {}
+
+    public Command(int ordinalPosition, String value) {
+      this.ordinalPosition = ordinalPosition;
+      this.value = value;
+    }
+
+    public int getKey() {
+      return ordinalPosition;
+    }
+
+    public void setKey(int key) {
+      this.ordinalPosition = key;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    public void setValue(String value) {
+      this.value = value;
+    }
+  }
+}

--- a/buildSrc/src/archetype-resources/src/main/java/subprocess/kernel/SubProcessIOFiles.java
+++ b/buildSrc/src/archetype-resources/src/main/java/subprocess/kernel/SubProcessIOFiles.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.subprocess.kernel;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+import ${package}.subprocess.configuration.SubProcessConfiguration;
+import ${package}.subprocess.utils.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * All information generated from the process will be stored in output files. The local working
+ * directory is used to generate three files with extension .err for standard error output .out for
+ * standard out output .ret for storing the results from the called library. The files will have a
+ * uuid created for them based on java.util.UUID
+ */
+public class SubProcessIOFiles implements Closeable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SubProcessIOFiles.class);
+
+  Path errFile;
+  Path outFile;
+  Path resultFile;
+  Path base;
+
+  String errFileLocation = "";
+  String outFileLocation = "";
+  String uuid;
+
+  public String getErrFileLocation() {
+    return errFileLocation;
+  }
+
+  public String getOutFileLocation() {
+    return outFileLocation;
+  }
+
+  /** @param workerWorkingDirectory */
+  public SubProcessIOFiles(String workerWorkingDirectory) {
+
+    this.uuid = UUID.randomUUID().toString();
+    base = Paths.get(workerWorkingDirectory);
+
+    // Setup all the redirect handles, including the return file type
+    errFile = Paths.get(base.toString(), uuid + ".err");
+    outFile = Paths.get(base.toString(), uuid + ".out");
+    resultFile = Paths.get(base.toString(), uuid + ".res");
+  }
+
+  public Path getErrFile() {
+    return errFile;
+  }
+
+  public Path getOutFile() {
+    return outFile;
+  }
+
+  public Path getResultFile() {
+    return resultFile;
+  }
+
+  /**
+   * Clean up the files that have been created on the local worker file system. Without this expect
+   * both performance issues and eventual failure
+   */
+  @Override
+  public void close() throws IOException {
+
+    if (Files.exists(outFile)) {
+      Files.delete(outFile);
+    }
+
+    if (Files.exists(errFile)) {
+      Files.delete(errFile);
+    }
+
+    if (Files.exists(resultFile)) {
+      Files.delete(resultFile);
+    }
+  }
+
+  /**
+   * Will copy the output files to the GCS path setup via the configuration.
+   *
+   * @param configuration
+   * @param params
+   */
+  public void copyOutPutFilesToBucket(SubProcessConfiguration configuration, String params) {
+    if (Files.exists(outFile) || Files.exists(errFile)) {
+      try {
+        outFileLocation = FileUtils.copyFileFromWorkerToGCS(configuration, outFile);
+      } catch (Exception ex) {
+        LOG.error("Error uploading log file to storage ", ex);
+      }
+
+      try {
+        errFileLocation = FileUtils.copyFileFromWorkerToGCS(configuration, errFile);
+      } catch (Exception ex) {
+        LOG.error("Error uploading log file to storage ", ex);
+      }
+
+      LOG.info(
+          String.format(
+              "Log Files for process: %s outFile was: %s errFile was: %s",
+              params, outFileLocation, errFileLocation));
+    } else {
+      LOG.error(String.format("There was no output file or err file for process %s", params));
+    }
+  }
+}

--- a/buildSrc/src/archetype-resources/src/main/java/subprocess/kernel/SubProcessKernel.java
+++ b/buildSrc/src/archetype-resources/src/main/java/subprocess/kernel/SubProcessKernel.java
@@ -1,0 +1,321 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.subprocess.kernel;
+
+import java.io.IOException;
+import java.lang.ProcessBuilder.Redirect;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import ${package}.subprocess.configuration.SubProcessConfiguration;
+import ${package}.subprocess.utils.CallingSubProcessUtils;
+import ${package}.subprocess.utils.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is the process kernel which deals with exec of the subprocess. It also deals with all I/O.
+ */
+public class SubProcessKernel {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SubProcessKernel.class);
+
+  private static final int MAX_SIZE_COMMAND_LINE_ARGS = 128 * 1024;
+
+  SubProcessConfiguration configuration;
+  ProcessBuilder processBuilder;
+
+  private SubProcessKernel() {}
+
+  /**
+   * Creates the SubProcess Kernel ready for execution. Will deal with all input and outputs to the
+   * SubProcess
+   *
+   * @param options
+   * @param binaryName
+   */
+  public SubProcessKernel(SubProcessConfiguration options, String binaryName) {
+    this.configuration = options;
+    this.processBuilder = new ProcessBuilder(binaryName);
+  }
+
+  public List<String> exec(SubProcessCommandLineArgs commands) throws Exception {
+    try (CallingSubProcessUtils.Permit permit =
+        new CallingSubProcessUtils.Permit(processBuilder.command().get(0))) {
+
+      List<String> results = null;
+
+      try (SubProcessIOFiles outputFiles = new SubProcessIOFiles(configuration.getWorkerPath())) {
+
+        try {
+          Process process = execBinary(processBuilder, commands, outputFiles);
+          results = collectProcessResults(process, processBuilder, outputFiles);
+        } catch (Exception ex) {
+          LOG.error("Error running executable ", ex);
+          throw ex;
+        }
+      } catch (IOException ex) {
+        LOG.error(
+            "Unable to delete the outputfiles. This can lead to performance issues and failure",
+            ex);
+      }
+      return results;
+    }
+  }
+
+  public byte[] execBinaryResult(SubProcessCommandLineArgs commands) throws Exception {
+    try (CallingSubProcessUtils.Permit permit =
+        new CallingSubProcessUtils.Permit(processBuilder.command().get(0))) {
+
+      try (SubProcessIOFiles outputFiles = new SubProcessIOFiles(configuration.getWorkerPath())) {
+
+        try {
+          Process process = execBinary(processBuilder, commands, outputFiles);
+          return collectProcessResultsBytes(process, processBuilder, outputFiles);
+        } catch (Exception ex) {
+          LOG.error("Error running executable ", ex);
+          throw ex;
+        }
+      } catch (IOException ex) {
+        LOG.error(
+            "Unable to delete the outputfiles. This can lead to performance issues and failure",
+            ex);
+      }
+      return new byte[0];
+    }
+  }
+
+  private ProcessBuilder prepareBuilder(
+      ProcessBuilder builder, SubProcessCommandLineArgs commands, SubProcessIOFiles outPutFiles)
+      throws IllegalStateException {
+
+    // Check we are not over the max size of command line parameters
+    if (getTotalCommandBytes(commands) > MAX_SIZE_COMMAND_LINE_ARGS) {
+      throw new IllegalStateException("Command is over 2MB in size");
+    }
+
+    appendExecutablePath(builder);
+
+    // Add the result file path to the builder at position 1, 0 is reserved for the process itself
+    builder.command().add(1, outPutFiles.resultFile.toString());
+
+    // Shift commands by 2 ordinal positions and load into the builder
+    for (SubProcessCommandLineArgs.Command s : commands.getParameters()) {
+      builder.command().add(s.ordinalPosition + 2, s.value);
+    }
+
+    builder.redirectError(Redirect.appendTo(outPutFiles.errFile.toFile()));
+    builder.redirectOutput(Redirect.appendTo(outPutFiles.outFile.toFile()));
+
+    return builder;
+  }
+
+  /**
+   * Add up the total bytes used by the process.
+   *
+   * @param commands
+   * @return
+   */
+  private int getTotalCommandBytes(SubProcessCommandLineArgs commands) {
+    int size = 0;
+    for (SubProcessCommandLineArgs.Command c : commands.getParameters()) {
+      size += c.value.length();
+    }
+    return size;
+  }
+
+  private Process execBinary(
+      ProcessBuilder builder, SubProcessCommandLineArgs commands, SubProcessIOFiles outPutFiles)
+      throws Exception {
+    try {
+
+      builder = prepareBuilder(builder, commands, outPutFiles);
+      Process process = builder.start();
+
+      boolean timeout = !process.waitFor(configuration.getWaitTime(), TimeUnit.SECONDS);
+
+      if (timeout) {
+        String log =
+            String.format(
+                "Timeout waiting to run process with parameters %s . "
+                    + "Check to see if your timeout is long enough. Currently set at %s.",
+                createLogEntryFromInputs(builder.command()), configuration.getWaitTime());
+        throw new Exception(log);
+      }
+      return process;
+
+    } catch (Exception ex) {
+
+      LOG.error(
+          String.format(
+              "Error running process with parameters %s error was %s ",
+              createLogEntryFromInputs(builder.command()), ex.getMessage()));
+      throw new Exception(ex);
+    }
+  }
+
+  /**
+   * TODO clean up duplicate with byte[] version collectBinaryProcessResults.
+   *
+   * @param process
+   * @param builder
+   * @param outPutFiles
+   * @return List of results
+   * @throws Exception if process has non 0 value or no logs found then throw exception
+   */
+  private List<String> collectProcessResults(
+      Process process, ProcessBuilder builder, SubProcessIOFiles outPutFiles) throws Exception {
+
+    List<String> results = new ArrayList<>();
+
+    try {
+
+      LOG.debug(String.format("Executing process %s", createLogEntryFromInputs(builder.command())));
+
+      // If process exit value is not 0 then subprocess failed, record logs
+      if (process.exitValue() != 0) {
+        outPutFiles.copyOutPutFilesToBucket(configuration, FileUtils.toStringParams(builder));
+        String log = createLogEntryForProcessFailure(process, builder.command(), outPutFiles);
+        throw new Exception(log);
+      }
+
+      // If no return file then either something went wrong or the binary is setup incorrectly for
+      // the ret file either way throw error
+      if (!Files.exists(outPutFiles.resultFile)) {
+        String log = createLogEntryForProcessFailure(process, builder.command(), outPutFiles);
+        outPutFiles.copyOutPutFilesToBucket(configuration, FileUtils.toStringParams(builder));
+        throw new Exception(log);
+      }
+
+      // Everything looks healthy return values
+      try (Stream<String> lines = Files.lines(outPutFiles.resultFile)) {
+        for (String line : (Iterable<String>) lines::iterator) {
+          results.add(line);
+        }
+      }
+      return results;
+    } catch (Exception ex) {
+      String log =
+          String.format(
+              "Unexpected error runnng process. %s error message was %s",
+              createLogEntryFromInputs(builder.command()), ex.getMessage());
+      throw new Exception(log);
+    }
+  }
+
+  /**
+   * Used when the reault file contains binary data.
+   *
+   * @param process
+   * @param builder
+   * @param outPutFiles
+   * @return Binary results
+   * @throws Exception if process has non 0 value or no logs found then throw exception
+   */
+  private byte[] collectProcessResultsBytes(
+      Process process, ProcessBuilder builder, SubProcessIOFiles outPutFiles) throws Exception {
+
+    Byte[] results;
+
+    try {
+
+      LOG.debug(String.format("Executing process %s", createLogEntryFromInputs(builder.command())));
+
+      // If process exit value is not 0 then subprocess failed, record logs
+      if (process.exitValue() != 0) {
+        outPutFiles.copyOutPutFilesToBucket(configuration, FileUtils.toStringParams(builder));
+        String log = createLogEntryForProcessFailure(process, builder.command(), outPutFiles);
+        throw new Exception(log);
+      }
+
+      // If no return file then either something went wrong or the binary is setup incorrectly for
+      // the ret file either way throw error
+      if (!Files.exists(outPutFiles.resultFile)) {
+        String log = createLogEntryForProcessFailure(process, builder.command(), outPutFiles);
+        outPutFiles.copyOutPutFilesToBucket(configuration, FileUtils.toStringParams(builder));
+        throw new Exception(log);
+      }
+
+      // Everything looks healthy return bytes
+      return Files.readAllBytes(outPutFiles.resultFile);
+
+    } catch (Exception ex) {
+      String log =
+          String.format(
+              "Unexpected error runnng process. %s error message was %s",
+              createLogEntryFromInputs(builder.command()), ex.getMessage());
+      throw new Exception(log);
+    }
+  }
+
+  private static String createLogEntryForProcessFailure(
+      Process process, List<String> commands, SubProcessIOFiles files) {
+
+    StringBuilder stringBuilder = new StringBuilder();
+
+    // Highlight when no result file is found vs standard process error
+    if (process.exitValue() == 0) {
+      stringBuilder.append(String.format("%nProcess succeded but no result file was found %n"));
+    } else {
+      stringBuilder.append(
+          String.format("%nProcess error failed with exit value of %s %n", process.exitValue()));
+    }
+
+    stringBuilder.append(
+        String.format("Command info was %s %n", createLogEntryFromInputs(commands)));
+
+    stringBuilder.append(
+        String.format(
+            "First line of error file is  %s %n", FileUtils.readLineOfLogFile(files.errFile)));
+
+    stringBuilder.append(
+        String.format(
+            "First line of out file is %s %n", FileUtils.readLineOfLogFile(files.outFile)));
+
+    stringBuilder.append(
+        String.format(
+            "First line of ret file is %s %n", FileUtils.readLineOfLogFile(files.resultFile)));
+
+    return stringBuilder.toString();
+  }
+
+  private static String createLogEntryFromInputs(List<String> commands) {
+    String params;
+    if (commands != null) {
+      params = String.join(",", commands);
+    } else {
+      params = "No-Commands";
+    }
+    return params;
+  }
+
+  // Pass the Path of the binary to the SubProcess in Command position 0
+  private ProcessBuilder appendExecutablePath(ProcessBuilder builder) {
+    String executable = builder.command().get(0);
+    if (executable == null) {
+      throw new IllegalArgumentException(
+          "No executable provided to the Process Builder... we will do... nothing... ");
+    }
+    builder
+        .command()
+        .set(0, FileUtils.getFileResourceId(configuration.getWorkerPath(), executable).toString());
+    return builder;
+  }
+}

--- a/buildSrc/src/archetype-resources/src/main/java/subprocess/utils/CallingSubProcessUtils.java
+++ b/buildSrc/src/archetype-resources/src/main/java/subprocess/utils/CallingSubProcessUtils.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.subprocess.utils;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
+import ${package}.subprocess.configuration.SubProcessConfiguration;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Utility class for dealing with concurrency and binary file copies to the worker. */
+public class CallingSubProcessUtils {
+
+  // Prevent Instantiation
+  private CallingSubProcessUtils() {}
+
+  static final Logger LOG = LoggerFactory.getLogger(CallingSubProcessUtils.class);
+
+  static boolean initCompleted = false;
+
+  // Allow multiple subclasses to create files, but only one thread per subclass can add the file to
+  // the worker
+  private static final Set<String> downloadedFiles = Sets.<String>newConcurrentHashSet();
+
+  // Limit the number of threads able to do work
+  private static Map<String, Semaphore> semaphores = new ConcurrentHashMap<>();
+
+  public static void setUp(SubProcessConfiguration configuration, String binaryName)
+      throws Exception {
+
+    if (!semaphores.containsKey(binaryName)) {
+      initSemaphore(configuration.getConcurrency(), binaryName);
+    }
+
+    synchronized (downloadedFiles) {
+      if (!downloadedFiles.contains(binaryName)) {
+        // Create Directories if needed
+        FileUtils.createDirectoriesOnWorker(configuration);
+        LOG.info("Calling filesetup to move Executables to worker.");
+        ExecutableFile executableFile = new ExecutableFile(configuration, binaryName);
+        FileUtils.copyFileFromGCSToWorker(executableFile);
+        downloadedFiles.add(binaryName);
+      }
+    }
+  }
+
+  public static synchronized void initSemaphore(Integer permits, String binaryName) {
+    if (!semaphores.containsKey(binaryName)) {
+      LOG.info(String.format(String.format("Initialized Semaphore for binary %s ", binaryName)));
+      semaphores.put(binaryName, new Semaphore(permits));
+    }
+  }
+
+  private static void aquireSemaphore(String binaryName) throws IllegalStateException {
+    if (!semaphores.containsKey(binaryName)) {
+      throw new IllegalStateException("Semaphore is NULL, check init logic in @Setup.");
+    }
+    try {
+      semaphores.get(binaryName).acquire();
+    } catch (InterruptedException ex) {
+      LOG.error("Interupted during aquire", ex);
+    }
+  }
+
+  private static void releaseSemaphore(String binaryName) throws IllegalStateException {
+    if (!semaphores.containsKey(binaryName)) {
+      throw new IllegalStateException("Semaphore is NULL, check init logic in @Setup.");
+    }
+    semaphores.get(binaryName).release();
+  }
+
+  /** Permit class for access to worker cpu resources. */
+  public static class Permit implements AutoCloseable {
+
+    private String binaryName;
+
+    public Permit(String binaryName) {
+      this.binaryName = binaryName;
+      CallingSubProcessUtils.aquireSemaphore(binaryName);
+    }
+
+    @Override
+    public void close() {
+      CallingSubProcessUtils.releaseSemaphore(binaryName);
+    }
+  }
+}

--- a/buildSrc/src/archetype-resources/src/main/java/subprocess/utils/ExecutableFile.java
+++ b/buildSrc/src/archetype-resources/src/main/java/subprocess/utils/ExecutableFile.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.subprocess.utils;
+
+import ${package}.subprocess.configuration.SubProcessConfiguration;
+import org.apache.beam.sdk.coders.AvroCoder;
+import org.apache.beam.sdk.coders.DefaultCoder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Contains the configuration for the external library. */
+@DefaultCoder(AvroCoder.class)
+public class ExecutableFile {
+
+  String fileName;
+
+  private String sourceGCSLocation;
+  private String destinationLocation;
+
+  static final Logger LOG = LoggerFactory.getLogger(ExecutableFile.class);
+
+  public String getSourceGCSLocation() {
+    return sourceGCSLocation;
+  }
+
+  public void setSourceGCSLocation(String sourceGCSLocation) {
+    this.sourceGCSLocation = sourceGCSLocation;
+  }
+
+  public String getDestinationLocation() {
+    return destinationLocation;
+  }
+
+  public void setDestinationLocation(String destinationLocation) {
+    this.destinationLocation = destinationLocation;
+  }
+
+  public ExecutableFile(SubProcessConfiguration configuration, String fileName)
+      throws IllegalStateException {
+    if (configuration == null) {
+      throw new IllegalStateException("Configuration can not be NULL");
+    }
+    if (fileName == null) {
+      throw new IllegalStateException("FileName can not be NULLt");
+    }
+    this.fileName = fileName;
+    setDestinationLocation(configuration);
+    setSourceLocation(configuration);
+  }
+
+  private void setDestinationLocation(SubProcessConfiguration configuration) {
+    this.sourceGCSLocation =
+        FileUtils.getFileResourceId(configuration.getSourcePath(), fileName).toString();
+  }
+
+  private void setSourceLocation(SubProcessConfiguration configuration) {
+    this.destinationLocation =
+        FileUtils.getFileResourceId(configuration.getWorkerPath(), fileName).toString();
+  }
+}

--- a/buildSrc/src/archetype-resources/src/main/java/subprocess/utils/FileUtils.java
+++ b/buildSrc/src/archetype-resources/src/main/java/subprocess/utils/FileUtils.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.subprocess.utils;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import ${package}.subprocess.configuration.SubProcessConfiguration;
+import org.apache.beam.sdk.io.FileSystems;
+import org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions;
+import org.apache.beam.sdk.io.fs.ResourceId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Utilities for dealing with movement of files from object stores and workers. */
+public class FileUtils {
+
+  private static final Logger LOG = LoggerFactory.getLogger(FileUtils.class);
+
+  public static ResourceId getFileResourceId(String directory, String fileName) {
+    ResourceId resourceID = FileSystems.matchNewResource(directory, true);
+    return resourceID.getCurrentDirectory().resolve(fileName, StandardResolveOptions.RESOLVE_FILE);
+  }
+
+  public static String toStringParams(ProcessBuilder builder) {
+    return String.join(",", builder.command());
+  }
+
+  public static String copyFileFromWorkerToGCS(
+      SubProcessConfiguration configuration, Path fileToUpload) throws Exception {
+
+    Path fileName;
+
+    if ((fileName = fileToUpload.getFileName()) == null) {
+      throw new IllegalArgumentException("FileName can not be null.");
+    }
+
+    ResourceId sourceFile = getFileResourceId(configuration.getWorkerPath(), fileName.toString());
+
+    LOG.info("Copying file from worker " + sourceFile);
+
+    ResourceId destinationFile =
+        getFileResourceId(configuration.getSourcePath(), fileName.toString());
+    // TODO currently not supported with different schemas for example GCS to local, else could use
+    // FileSystems.copy(ImmutableList.of(sourceFile), ImmutableList.of(destinationFile));
+    try {
+      return copyFile(sourceFile, destinationFile);
+    } catch (Exception ex) {
+      LOG.error(
+          String.format("Error copying file from %s  to %s", sourceFile, destinationFile), ex);
+      throw ex;
+    }
+  }
+
+  public static String copyFileFromGCSToWorker(ExecutableFile execuableFile) throws Exception {
+
+    ResourceId sourceFile =
+        FileSystems.matchNewResource(execuableFile.getSourceGCSLocation(), false);
+    ResourceId destinationFile =
+        FileSystems.matchNewResource(execuableFile.getDestinationLocation(), false);
+    try {
+      LOG.info(
+          String.format(
+              "Moving File %s to %s ",
+              execuableFile.getSourceGCSLocation(), execuableFile.getDestinationLocation()));
+      Path path = Paths.get(execuableFile.getDestinationLocation());
+
+      if (path.toFile().exists()) {
+        LOG.warn(
+            String.format(
+                "Overwriting file %s, should only see this once per worker.",
+                execuableFile.getDestinationLocation()));
+      }
+      copyFile(sourceFile, destinationFile);
+      path.toFile().setExecutable(true);
+      return path.toString();
+
+    } catch (Exception ex) {
+      LOG.error(String.format("Error moving file : %s ", execuableFile.fileName), ex);
+      throw ex;
+    }
+  }
+
+  public static String copyFile(ResourceId sourceFile, ResourceId destinationFile)
+      throws IOException {
+
+    try (WritableByteChannel writeChannel = FileSystems.create(destinationFile, "text/plain")) {
+      try (ReadableByteChannel readChannel = FileSystems.open(sourceFile)) {
+
+        final ByteBuffer buffer = ByteBuffer.allocateDirect(16 * 1024);
+        while (readChannel.read(buffer) != -1) {
+          buffer.flip();
+          writeChannel.write(buffer);
+          buffer.compact();
+        }
+        buffer.flip();
+        while (buffer.hasRemaining()) {
+          writeChannel.write(buffer);
+        }
+      }
+    }
+
+    return destinationFile.toString();
+  }
+
+  /**
+   * Create directories needed based on configuration.
+   *
+   * @param configuration
+   * @throws IOException
+   */
+  public static void createDirectoriesOnWorker(SubProcessConfiguration configuration)
+      throws IOException {
+
+    try {
+
+      Path path = Paths.get(configuration.getWorkerPath());
+
+      if (!path.toFile().exists()) {
+        Files.createDirectories(path);
+        LOG.info(String.format("Created Folder %s ", path.toFile()));
+      }
+    } catch (FileAlreadyExistsException ex) {
+      LOG.warn(
+          String.format(
+              " Tried to create folder %s which already existsed, this should not happen!",
+              configuration.getWorkerPath()),
+          ex);
+    }
+  }
+
+  public static String readLineOfLogFile(Path path) {
+
+    try (BufferedReader br = Files.newBufferedReader(Paths.get(path.toString()), UTF_8)) {
+      return br.readLine();
+    } catch (IOException e) {
+      LOG.error("Error reading the first line of file", e);
+    }
+
+    // `return empty string rather than NULL string as this data is often used in further logging
+    return "";
+  }
+}

--- a/buildSrc/src/archetype-resources/src/test/java/DebuggingWordCountTest.java
+++ b/buildSrc/src/archetype-resources/src/test/java/DebuggingWordCountTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package};
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import ${package}.DebuggingWordCount.WordCountOptions;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.io.Files;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link DebuggingWordCount}. */
+@RunWith(JUnit4.class)
+public class DebuggingWordCountTest {
+  @Rule public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+  private String getFilePath(String filePath) {
+    if (filePath.contains(":")) {
+      return filePath.replace("\\", "/").split(":", -1)[1];
+    }
+    return filePath;
+  }
+
+  @Test
+  public void testDebuggingWordCount() throws Exception {
+    File inputFile = tmpFolder.newFile();
+    File outputFile = tmpFolder.newFile();
+    Files.write(
+        "stomach secret Flourish message Flourish here Flourish",
+        inputFile,
+        StandardCharsets.UTF_8);
+    WordCountOptions options = TestPipeline.testingPipelineOptions().as(WordCountOptions.class);
+    options.setInputFile(getFilePath(inputFile.getAbsolutePath()));
+    options.setOutput(getFilePath(outputFile.getAbsolutePath()));
+    DebuggingWordCount.runDebuggingWordCount(options);
+  }
+}

--- a/buildSrc/src/archetype-resources/src/test/java/MinimalWordCountTest.java
+++ b/buildSrc/src/archetype-resources/src/test/java/MinimalWordCountTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package};
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import org.apache.beam.sdk.extensions.gcp.options.GcsOptions;
+import org.apache.beam.sdk.extensions.gcp.util.GcsUtil;
+import org.apache.beam.sdk.extensions.gcp.util.gcsfs.GcsPath;
+import org.apache.beam.sdk.io.TextIO;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Count;
+import org.apache.beam.sdk.transforms.Filter;
+import org.apache.beam.sdk.transforms.FlatMapElements;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.TypeDescriptors;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+/**
+ * To keep {@link MinimalWordCount} simple, it is not factored or testable. This test file should be
+ * maintained with a copy of its code for a basic smoke test.
+ */
+@RunWith(JUnit4.class)
+public class MinimalWordCountTest implements Serializable {
+
+  @Rule public TestPipeline p = TestPipeline.create().enableAbandonedNodeEnforcement(false);
+
+  /** A basic smoke test that ensures there is no crash at pipeline construction time. */
+  @Test
+  public void testMinimalWordCount() throws Exception {
+    p.getOptions().as(GcsOptions.class).setGcsUtil(buildMockGcsUtil());
+
+    p.apply(TextIO.read().from("gs://apache-beam-samples/shakespeare/*"))
+        .apply(
+            FlatMapElements.into(TypeDescriptors.strings())
+                .via((String word) -> Arrays.asList(word.split("[^a-zA-Z']+"))))
+        .apply(Filter.by((String word) -> !word.isEmpty()))
+        .apply(Count.perElement())
+        .apply(
+            MapElements.into(TypeDescriptors.strings())
+                .via(
+                    (KV<String, Long> wordCount) ->
+                        wordCount.getKey() + ": " + wordCount.getValue()))
+        .apply(TextIO.write().to("gs://your-output-bucket/and-output-prefix"));
+  }
+
+  private GcsUtil buildMockGcsUtil() throws IOException {
+    GcsUtil mockGcsUtil = Mockito.mock(GcsUtil.class);
+
+    // Any request to open gets a new bogus channel
+    Mockito.when(mockGcsUtil.open(Mockito.any(GcsPath.class)))
+        .then(
+            invocation ->
+                FileChannel.open(
+                    Files.createTempFile("channel-", ".tmp"),
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.DELETE_ON_CLOSE));
+
+    // Any request for expansion returns a list containing the original GcsPath
+    // This is required to pass validation that occurs in TextIO during apply()
+    Mockito.when(mockGcsUtil.expand(Mockito.any(GcsPath.class)))
+        .then(invocation -> ImmutableList.of((GcsPath) invocation.getArguments()[0]));
+
+    return mockGcsUtil;
+  }
+}

--- a/buildSrc/src/archetype-resources/src/test/java/WordCountTest.java
+++ b/buildSrc/src/archetype-resources/src/test/java/WordCountTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package};
+
+import java.util.Arrays;
+import java.util.List;
+import ${package}.WordCount.CountWords;
+import ${package}.WordCount.ExtractWordsFn;
+import ${package}.WordCount.FormatAsTextFn;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.ValidatesRunner;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.PCollection;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests of WordCount. */
+@RunWith(JUnit4.class)
+public class WordCountTest {
+
+  /** Example test that tests a specific {@link DoFn}. */
+  @Test
+  public void testExtractWordsFn() throws Exception {
+    List<String> words = Arrays.asList(" some  input  words ", " ", " cool ", " foo", " bar");
+    PCollection<String> output =
+        p.apply(Create.of(words).withCoder(StringUtf8Coder.of()))
+            .apply(ParDo.of(new ExtractWordsFn()));
+    PAssert.that(output).containsInAnyOrder("some", "input", "words", "cool", "foo", "bar");
+    p.run().waitUntilFinish();
+  }
+
+  static final String[] WORDS_ARRAY =
+      new String[] {
+        "hi there", "hi", "hi sue bob",
+        "hi sue", "", "bob hi"
+      };
+
+  static final List<String> WORDS = Arrays.asList(WORDS_ARRAY);
+
+  static final String[] COUNTS_ARRAY = new String[] {"hi: 5", "there: 1", "sue: 2", "bob: 2"};
+
+  @Rule public TestPipeline p = TestPipeline.create();
+
+  /** Example test that tests a PTransform by using an in-memory input and inspecting the output. */
+  @Test
+  @Category(ValidatesRunner.class)
+  public void testCountWords() throws Exception {
+    PCollection<String> input = p.apply(Create.of(WORDS).withCoder(StringUtf8Coder.of()));
+
+    PCollection<String> output =
+        input.apply(new CountWords()).apply(MapElements.via(new FormatAsTextFn()));
+
+    PAssert.that(output).containsInAnyOrder(COUNTS_ARRAY);
+    p.run().waitUntilFinish();
+  }
+}

--- a/buildSrc/src/archetype-resources/src/test/java/complete/game/GameStatsTest.java
+++ b/buildSrc/src/archetype-resources/src/test/java/complete/game/GameStatsTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.complete.game;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import ${package}.complete.game.GameStats.CalculateSpammyUsers;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.ValidatesRunner;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests of GameStats. Because the pipeline was designed for easy readability and explanations, it
+ * lacks good modularity for testing. See our testing documentation for better ideas:
+ * https://beam.apache.org/documentation/pipelines/test-your-pipeline/
+ */
+@RunWith(JUnit4.class)
+public class GameStatsTest implements Serializable {
+
+  // User scores
+  static final List<KV<String, Integer>> USER_SCORES =
+      Arrays.asList(
+          KV.of("Robot-2", 66),
+          KV.of("Robot-1", 116),
+          KV.of("user7_AndroidGreenKookaburra", 23),
+          KV.of("user7_AndroidGreenKookaburra", 1),
+          KV.of("user19_BisqueBilby", 14),
+          KV.of("user13_ApricotQuokka", 15),
+          KV.of("user18_BananaEmu", 25),
+          KV.of("user6_AmberEchidna", 8),
+          KV.of("user2_AmberQuokka", 6),
+          KV.of("user0_MagentaKangaroo", 4),
+          KV.of("user0_MagentaKangaroo", 3),
+          KV.of("user2_AmberCockatoo", 13),
+          KV.of("user7_AlmondWallaby", 15),
+          KV.of("user6_AmberNumbat", 11),
+          KV.of("user6_AmberQuokka", 4));
+
+  // The expected list of 'spammers'.
+  static final List<KV<String, Integer>> SPAMMERS =
+      Arrays.asList(KV.of("Robot-2", 66), KV.of("Robot-1", 116));
+
+  @Rule public TestPipeline p = TestPipeline.create();
+
+  /** Test the calculation of 'spammy users'. */
+  @Test
+  @Category(ValidatesRunner.class)
+  public void testCalculateSpammyUsers() throws Exception {
+    PCollection<KV<String, Integer>> input = p.apply(Create.of(USER_SCORES));
+    PCollection<KV<String, Integer>> output = input.apply(new CalculateSpammyUsers());
+
+    // Check the set of spammers.
+    PAssert.that(output).containsInAnyOrder(SPAMMERS);
+
+    p.run().waitUntilFinish();
+  }
+
+  @Test
+  public void testGameStatsOptions() {
+    PipelineOptionsFactory.as(GameStats.Options.class);
+  }
+}

--- a/buildSrc/src/archetype-resources/src/test/java/complete/game/HourlyTeamScoreTest.java
+++ b/buildSrc/src/archetype-resources/src/test/java/complete/game/HourlyTeamScoreTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.complete.game;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import ${package}.complete.game.UserScore.GameActionInfo;
+import ${package}.complete.game.UserScore.ParseEventFn;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.ValidatesRunner;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.Filter;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TypeDescriptors;
+import org.joda.time.Instant;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests of HourlyTeamScore. Because the pipeline was designed for easy readability and
+ * explanations, it lacks good modularity for testing. See our testing documentation for better
+ * ideas: https://beam.apache.org/documentation/pipelines/test-your-pipeline/
+ */
+@RunWith(JUnit4.class)
+public class HourlyTeamScoreTest implements Serializable {
+
+  static final String[] GAME_EVENTS_ARRAY =
+      new String[] {
+        "user0_MagentaKangaroo,MagentaKangaroo,3,1447955630000,2015-11-19 09:53:53.444",
+        "user13_ApricotQuokka,ApricotQuokka,15,1447955630000,2015-11-19 09:53:53.444",
+        "user6_AmberNumbat,AmberNumbat,11,1447955630000,2015-11-19 09:53:53.444",
+        "user7_AlmondWallaby,AlmondWallaby,15,1447955630000,2015-11-19 09:53:53.444",
+        "user7_AndroidGreenKookaburra,AndroidGreenKookaburra,12,1447955630000,2015-11-19 09:53:53.444",
+        "user7_AndroidGreenKookaburra,AndroidGreenKookaburra,11,1447955630000,2015-11-19 09:53:53.444",
+        "user19_BisqueBilby,BisqueBilby,6,1447955630000,2015-11-19 09:53:53.444",
+        "user19_BisqueBilby,BisqueBilby,8,1447955630000,2015-11-19 09:53:53.444",
+        // time gap...
+        "user0_AndroidGreenEchidna,AndroidGreenEchidna,0,1447965690000,2015-11-19 12:41:31.053",
+        "user0_MagentaKangaroo,MagentaKangaroo,4,1447965690000,2015-11-19 12:41:31.053",
+        "user2_AmberCockatoo,AmberCockatoo,13,1447965690000,2015-11-19 12:41:31.053",
+        "user18_BananaEmu,BananaEmu,7,1447965690000,2015-11-19 12:41:31.053",
+        "user3_BananaEmu,BananaEmu,17,1447965690000,2015-11-19 12:41:31.053",
+        "user18_BananaEmu,BananaEmu,1,1447965690000,2015-11-19 12:41:31.053",
+        "user18_ApricotCaneToad,ApricotCaneToad,14,1447965690000,2015-11-19 12:41:31.053"
+      };
+
+  static final List<String> GAME_EVENTS = Arrays.asList(GAME_EVENTS_ARRAY);
+
+  // Used to check the filtering.
+  static final KV[] FILTERED_EVENTS =
+      new KV[] {
+        KV.of("user0_AndroidGreenEchidna", 0),
+        KV.of("user0_MagentaKangaroo", 4),
+        KV.of("user2_AmberCockatoo", 13),
+        KV.of("user18_BananaEmu", 7),
+        KV.of("user3_BananaEmu", 17),
+        KV.of("user18_BananaEmu", 1),
+        KV.of("user18_ApricotCaneToad", 14)
+      };
+
+  @Rule public TestPipeline p = TestPipeline.create();
+
+  /** Test the filtering. */
+  @Test
+  @Category(ValidatesRunner.class)
+  public void testUserScoresFilter() throws Exception {
+
+    final Instant startMinTimestamp = new Instant(1447965680000L);
+
+    PCollection<String> input = p.apply(Create.of(GAME_EVENTS).withCoder(StringUtf8Coder.of()));
+
+    PCollection<KV<String, Integer>> output =
+        input
+            .apply("ParseGameEvent", ParDo.of(new ParseEventFn()))
+            .apply(
+                "FilterStartTime",
+                Filter.by(
+                    (GameActionInfo gInfo) -> gInfo.getTimestamp() > startMinTimestamp.getMillis()))
+            // run a map to access the fields in the result.
+            .apply(
+                MapElements.into(
+                        TypeDescriptors.kvs(TypeDescriptors.strings(), TypeDescriptors.integers()))
+                    .via((GameActionInfo gInfo) -> KV.of(gInfo.getUser(), gInfo.getScore())));
+
+    PAssert.that(output).containsInAnyOrder(FILTERED_EVENTS);
+
+    p.run().waitUntilFinish();
+  }
+
+  @Test
+  public void testUserScoreOptions() {
+    PipelineOptionsFactory.as(HourlyTeamScore.Options.class);
+  }
+}

--- a/buildSrc/src/archetype-resources/src/test/java/complete/game/LeaderBoardTest.java
+++ b/buildSrc/src/archetype-resources/src/test/java/complete/game/LeaderBoardTest.java
@@ -1,0 +1,394 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.complete.game;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.Assert.assertThat;
+
+import java.io.Serializable;
+import ${package}.complete.game.LeaderBoard.CalculateTeamScores;
+import ${package}.complete.game.LeaderBoard.CalculateUserScores;
+import ${package}.complete.game.UserScore.GameActionInfo;
+import org.apache.beam.sdk.coders.AvroCoder;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.TestStream;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TimestampedValue;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link LeaderBoard}. */
+@RunWith(JUnit4.class)
+public class LeaderBoardTest implements Serializable {
+  private static final Duration ALLOWED_LATENESS = Duration.standardHours(1);
+  private static final Duration TEAM_WINDOW_DURATION = Duration.standardMinutes(20);
+  private Instant baseTime = new Instant(0);
+
+  @Rule public TestPipeline p = TestPipeline.create();
+  /** Some example users, on two separate teams. */
+  private enum TestUser {
+    RED_ONE("scarlet", "red"),
+    RED_TWO("burgundy", "red"),
+    BLUE_ONE("navy", "blue"),
+    BLUE_TWO("sky", "blue");
+
+    private final String userName;
+    private final String teamName;
+
+    TestUser(String userName, String teamName) {
+      this.userName = userName;
+      this.teamName = teamName;
+    }
+
+    public String getUser() {
+      return userName;
+    }
+
+    public String getTeam() {
+      return teamName;
+    }
+  }
+
+  /**
+   * A test of the {@link CalculateTeamScores} {@link PTransform} when all of the elements arrive on
+   * time (ahead of the watermark).
+   */
+  @Test
+  public void testTeamScoresOnTime() {
+
+    TestStream<GameActionInfo> createEvents =
+        TestStream.create(AvroCoder.of(GameActionInfo.class))
+            // Start at the epoch
+            .advanceWatermarkTo(baseTime)
+            // add some elements ahead of the watermark
+            .addElements(
+                event(TestUser.BLUE_ONE, 3, Duration.standardSeconds(3)),
+                event(TestUser.BLUE_ONE, 2, Duration.standardMinutes(1)),
+                event(TestUser.RED_TWO, 3, Duration.standardSeconds(22)),
+                event(TestUser.BLUE_TWO, 5, Duration.standardMinutes(3)))
+            // The watermark advances slightly, but not past the end of the window
+            .advanceWatermarkTo(baseTime.plus(Duration.standardMinutes(3)))
+            // Add some more on time elements
+            .addElements(
+                event(TestUser.RED_ONE, 1, Duration.standardMinutes(4)),
+                event(TestUser.BLUE_ONE, 2, Duration.standardSeconds(270)))
+            // The window should close and emit an ON_TIME pane
+            .advanceWatermarkToInfinity();
+
+    PCollection<KV<String, Integer>> teamScores =
+        p.apply(createEvents)
+            .apply(new CalculateTeamScores(TEAM_WINDOW_DURATION, ALLOWED_LATENESS));
+
+    String blueTeam = TestUser.BLUE_ONE.getTeam();
+    String redTeam = TestUser.RED_ONE.getTeam();
+    PAssert.that(teamScores)
+        .inOnTimePane(new IntervalWindow(baseTime, TEAM_WINDOW_DURATION))
+        .containsInAnyOrder(KV.of(blueTeam, 12), KV.of(redTeam, 4));
+
+    p.run().waitUntilFinish();
+  }
+
+  /**
+   * A test of the {@link CalculateTeamScores} {@link PTransform} when all of the elements arrive on
+   * time, and the processing time advances far enough for speculative panes.
+   */
+  @Test
+  public void testTeamScoresSpeculative() {
+
+    TestStream<GameActionInfo> createEvents =
+        TestStream.create(AvroCoder.of(GameActionInfo.class))
+            // Start at the epoch
+            .advanceWatermarkTo(baseTime)
+            .addElements(
+                event(TestUser.BLUE_ONE, 3, Duration.standardSeconds(3)),
+                event(TestUser.BLUE_ONE, 2, Duration.standardMinutes(1)))
+            // Some time passes within the runner, which causes a speculative pane containing the
+            // blue
+            // team's score to be emitted
+            .advanceProcessingTime(Duration.standardMinutes(10))
+            .addElements(event(TestUser.RED_TWO, 5, Duration.standardMinutes(3)))
+            // Some additional time passes and we get a speculative pane for the red team
+            .advanceProcessingTime(Duration.standardMinutes(12))
+            .addElements(event(TestUser.BLUE_TWO, 3, Duration.standardSeconds(22)))
+            // More time passes and a speculative pane containing a refined value for the blue pane
+            // is
+            // emitted
+            .advanceProcessingTime(Duration.standardMinutes(10))
+            // Some more events occur
+            .addElements(
+                event(TestUser.RED_ONE, 4, Duration.standardMinutes(4)),
+                event(TestUser.BLUE_TWO, 2, Duration.standardMinutes(2)))
+            // The window closes and we get an ON_TIME pane that contains all of the updates
+            .advanceWatermarkToInfinity();
+
+    PCollection<KV<String, Integer>> teamScores =
+        p.apply(createEvents)
+            .apply(new CalculateTeamScores(TEAM_WINDOW_DURATION, ALLOWED_LATENESS));
+
+    String blueTeam = TestUser.BLUE_ONE.getTeam();
+    String redTeam = TestUser.RED_ONE.getTeam();
+    IntervalWindow window = new IntervalWindow(baseTime, TEAM_WINDOW_DURATION);
+    // The window contains speculative panes alongside the on-time pane
+    PAssert.that(teamScores)
+        .inWindow(window)
+        .containsInAnyOrder(
+            KV.of(blueTeam, 10) /* The on-time blue pane */,
+            KV.of(redTeam, 9) /* The on-time red pane */,
+            KV.of(blueTeam, 5) /* The first blue speculative pane */,
+            KV.of(blueTeam, 8) /* The second blue speculative pane */,
+            KV.of(redTeam, 5) /* The red speculative pane */);
+    PAssert.that(teamScores)
+        .inOnTimePane(window)
+        .containsInAnyOrder(KV.of(blueTeam, 10), KV.of(redTeam, 9));
+
+    p.run().waitUntilFinish();
+  }
+
+  /**
+   * A test where elements arrive behind the watermark (late data), but before the end of the
+   * window. These elements are emitted on time.
+   */
+  @Test
+  public void testTeamScoresUnobservablyLate() {
+
+    BoundedWindow window = new IntervalWindow(baseTime, TEAM_WINDOW_DURATION);
+    TestStream<GameActionInfo> createEvents =
+        TestStream.create(AvroCoder.of(GameActionInfo.class))
+            .advanceWatermarkTo(baseTime)
+            .addElements(
+                event(TestUser.BLUE_ONE, 3, Duration.standardSeconds(3)),
+                event(TestUser.BLUE_TWO, 5, Duration.standardMinutes(8)),
+                event(TestUser.RED_ONE, 4, Duration.standardMinutes(2)),
+                event(TestUser.BLUE_ONE, 3, Duration.standardMinutes(5)))
+            .advanceWatermarkTo(
+                baseTime.plus(TEAM_WINDOW_DURATION).minus(Duration.standardMinutes(1)))
+            // These events are late, but the window hasn't closed yet, so the elements are in the
+            // on-time pane
+            .addElements(
+                event(TestUser.RED_TWO, 2, Duration.ZERO),
+                event(TestUser.RED_TWO, 5, Duration.standardMinutes(1)),
+                event(TestUser.BLUE_TWO, 2, Duration.standardSeconds(90)),
+                event(TestUser.RED_TWO, 3, Duration.standardMinutes(3)))
+            .advanceWatermarkTo(
+                baseTime.plus(TEAM_WINDOW_DURATION).plus(Duration.standardMinutes(1)))
+            .advanceWatermarkToInfinity();
+    PCollection<KV<String, Integer>> teamScores =
+        p.apply(createEvents)
+            .apply(new CalculateTeamScores(TEAM_WINDOW_DURATION, ALLOWED_LATENESS));
+
+    String blueTeam = TestUser.BLUE_ONE.getTeam();
+    String redTeam = TestUser.RED_ONE.getTeam();
+    // The On Time pane contains the late elements that arrived before the end of the window
+    PAssert.that(teamScores)
+        .inOnTimePane(window)
+        .containsInAnyOrder(KV.of(redTeam, 14), KV.of(blueTeam, 13));
+
+    p.run().waitUntilFinish();
+  }
+
+  /**
+   * A test where elements arrive behind the watermark (late data) after the watermark passes the
+   * end of the window, but before the maximum allowed lateness. These elements are emitted in a
+   * late pane.
+   */
+  @Test
+  public void testTeamScoresObservablyLate() {
+
+    Instant firstWindowCloses = baseTime.plus(ALLOWED_LATENESS).plus(TEAM_WINDOW_DURATION);
+    TestStream<GameActionInfo> createEvents =
+        TestStream.create(AvroCoder.of(GameActionInfo.class))
+            .advanceWatermarkTo(baseTime)
+            .addElements(
+                event(TestUser.BLUE_ONE, 3, Duration.standardSeconds(3)),
+                event(TestUser.BLUE_TWO, 5, Duration.standardMinutes(8)))
+            .advanceProcessingTime(Duration.standardMinutes(10))
+            .advanceWatermarkTo(baseTime.plus(Duration.standardMinutes(3)))
+            .addElements(
+                event(TestUser.RED_ONE, 3, Duration.standardMinutes(1)),
+                event(TestUser.RED_ONE, 4, Duration.standardMinutes(2)),
+                event(TestUser.BLUE_ONE, 3, Duration.standardMinutes(5)))
+            .advanceWatermarkTo(firstWindowCloses.minus(Duration.standardMinutes(1)))
+            // These events are late but should still appear in a late pane
+            .addElements(
+                event(TestUser.RED_TWO, 2, Duration.ZERO),
+                event(TestUser.RED_TWO, 5, Duration.standardMinutes(1)),
+                event(TestUser.RED_TWO, 3, Duration.standardMinutes(3)))
+            // A late refinement is emitted due to the advance in processing time, but the window
+            // has
+            // not yet closed because the watermark has not advanced
+            .advanceProcessingTime(Duration.standardMinutes(12))
+            // These elements should appear in the final pane
+            .addElements(
+                event(TestUser.RED_TWO, 9, Duration.standardMinutes(1)),
+                event(TestUser.RED_TWO, 1, Duration.standardMinutes(3)))
+            .advanceWatermarkToInfinity();
+
+    PCollection<KV<String, Integer>> teamScores =
+        p.apply(createEvents)
+            .apply(new CalculateTeamScores(TEAM_WINDOW_DURATION, ALLOWED_LATENESS));
+
+    BoundedWindow window = new IntervalWindow(baseTime, TEAM_WINDOW_DURATION);
+    String blueTeam = TestUser.BLUE_ONE.getTeam();
+    String redTeam = TestUser.RED_ONE.getTeam();
+    PAssert.that(teamScores)
+        .inWindow(window)
+        .satisfies(
+            input -> {
+              // The final sums need not exist in the same pane, but must appear in the output
+              // PCollection
+              assertThat(input, hasItem(KV.of(blueTeam, 11)));
+              assertThat(input, hasItem(KV.of(redTeam, 27)));
+              return null;
+            });
+    PAssert.thatMap(teamScores)
+        // The closing behavior of CalculateTeamScores precludes an inFinalPane matcher
+        .inOnTimePane(window)
+        .isEqualTo(
+            ImmutableMap.<String, Integer>builder().put(redTeam, 7).put(blueTeam, 11).build());
+
+    // No final pane is emitted for the blue team, as all of their updates have been taken into
+    // account in earlier panes
+    PAssert.that(teamScores).inFinalPane(window).containsInAnyOrder(KV.of(redTeam, 27));
+
+    p.run().waitUntilFinish();
+  }
+
+  /**
+   * A test where elements arrive beyond the maximum allowed lateness. These elements are dropped
+   * within {@link CalculateTeamScores} and do not impact the final result.
+   */
+  @Test
+  public void testTeamScoresDroppablyLate() {
+
+    BoundedWindow window = new IntervalWindow(baseTime, TEAM_WINDOW_DURATION);
+    TestStream<GameActionInfo> infos =
+        TestStream.create(AvroCoder.of(GameActionInfo.class))
+            .addElements(
+                event(TestUser.BLUE_ONE, 12, Duration.ZERO),
+                event(TestUser.RED_ONE, 3, Duration.ZERO))
+            .advanceWatermarkTo(window.maxTimestamp())
+            .addElements(
+                event(TestUser.RED_ONE, 4, Duration.standardMinutes(2)),
+                event(TestUser.BLUE_TWO, 3, Duration.ZERO),
+                event(TestUser.BLUE_ONE, 3, Duration.standardMinutes(3)))
+            // Move the watermark to the end of the window to output on time
+            .advanceWatermarkTo(baseTime.plus(TEAM_WINDOW_DURATION))
+            // Move the watermark past the end of the allowed lateness plus the end of the window
+            .advanceWatermarkTo(
+                baseTime
+                    .plus(ALLOWED_LATENESS)
+                    .plus(TEAM_WINDOW_DURATION)
+                    .plus(Duration.standardMinutes(1)))
+            // These elements within the expired window are droppably late, and will not appear in
+            // the
+            // output
+            .addElements(
+                event(
+                    TestUser.BLUE_TWO, 3, TEAM_WINDOW_DURATION.minus(Duration.standardSeconds(5))),
+                event(TestUser.RED_ONE, 7, Duration.standardMinutes(4)))
+            .advanceWatermarkToInfinity();
+    PCollection<KV<String, Integer>> teamScores =
+        p.apply(infos).apply(new CalculateTeamScores(TEAM_WINDOW_DURATION, ALLOWED_LATENESS));
+
+    String blueTeam = TestUser.BLUE_ONE.getTeam();
+    String redTeam = TestUser.RED_ONE.getTeam();
+    // Only one on-time pane and no late panes should be emitted
+    PAssert.that(teamScores)
+        .inWindow(window)
+        .containsInAnyOrder(KV.of(redTeam, 7), KV.of(blueTeam, 18));
+    // No elements are added before the watermark passes the end of the window plus the allowed
+    // lateness, so no refinement should be emitted
+    PAssert.that(teamScores).inFinalPane(window).empty();
+
+    p.run().waitUntilFinish();
+  }
+
+  /**
+   * A test where elements arrive both on-time and late in {@link CalculateUserScores}, which emits
+   * output into the {@link GlobalWindow}. All elements that arrive should be taken into account,
+   * even if they arrive later than the maximum allowed lateness.
+   */
+  @Test
+  public void testUserScore() {
+
+    TestStream<GameActionInfo> infos =
+        TestStream.create(AvroCoder.of(GameActionInfo.class))
+            .addElements(
+                event(TestUser.BLUE_ONE, 12, Duration.ZERO),
+                event(TestUser.RED_ONE, 3, Duration.ZERO))
+            .advanceProcessingTime(Duration.standardMinutes(7))
+            .addElements(
+                event(TestUser.RED_ONE, 4, Duration.standardMinutes(2)),
+                event(TestUser.BLUE_TWO, 3, Duration.ZERO),
+                event(TestUser.BLUE_ONE, 3, Duration.standardMinutes(3)))
+            .advanceProcessingTime(Duration.standardMinutes(5))
+            .advanceWatermarkTo(baseTime.plus(ALLOWED_LATENESS).plus(Duration.standardHours(12)))
+            // Late elements are always observable within the global window - they arrive before
+            // the window closes, so they will appear in a pane, even if they arrive after the
+            // allowed lateness, and are taken into account alongside on-time elements
+            .addElements(
+                event(TestUser.RED_ONE, 3, Duration.standardMinutes(7)),
+                event(TestUser.RED_ONE, 2, ALLOWED_LATENESS.plus(Duration.standardHours(13))))
+            .advanceProcessingTime(Duration.standardMinutes(6))
+            .addElements(event(TestUser.BLUE_TWO, 5, Duration.standardMinutes(12)))
+            .advanceProcessingTime(Duration.standardMinutes(20))
+            .advanceWatermarkToInfinity();
+
+    PCollection<KV<String, Integer>> userScores =
+        p.apply(infos).apply(new CalculateUserScores(ALLOWED_LATENESS));
+
+    // User scores are emitted in speculative panes in the Global Window - this matcher choice
+    // ensures that panes emitted by the watermark advancing to positive infinity are not included,
+    // as that will not occur outside of tests
+    PAssert.that(userScores)
+        .inEarlyGlobalWindowPanes()
+        .containsInAnyOrder(
+            KV.of(TestUser.BLUE_ONE.getUser(), 15),
+            KV.of(TestUser.RED_ONE.getUser(), 7),
+            KV.of(TestUser.RED_ONE.getUser(), 12),
+            KV.of(TestUser.BLUE_TWO.getUser(), 3),
+            KV.of(TestUser.BLUE_TWO.getUser(), 8));
+
+    p.run().waitUntilFinish();
+  }
+
+  @Test
+  public void testLeaderBoardOptions() {
+    PipelineOptionsFactory.as(LeaderBoard.Options.class);
+  }
+
+  private TimestampedValue<GameActionInfo> event(
+      TestUser user, int score, Duration baseTimeOffset) {
+    return TimestampedValue.of(
+        new GameActionInfo(
+            user.getUser(), user.getTeam(), score, baseTime.plus(baseTimeOffset).getMillis()),
+        baseTime.plus(baseTimeOffset));
+  }
+}

--- a/buildSrc/src/archetype-resources/src/test/java/complete/game/StatefulTeamScoreTest.java
+++ b/buildSrc/src/archetype-resources/src/test/java/complete/game/StatefulTeamScoreTest.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.complete.game;
+
+import ${package}.complete.game.StatefulTeamScore.UpdateTeamScoreFn;
+import ${package}.complete.game.UserScore.GameActionInfo;
+import org.apache.beam.sdk.coders.AvroCoder;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.TestStream;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.windowing.FixedWindows;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
+import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TimestampedValue;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link StatefulTeamScore}. */
+@RunWith(JUnit4.class)
+public class StatefulTeamScoreTest {
+
+  private Instant baseTime = new Instant(0);
+
+  @Rule public TestPipeline p = TestPipeline.create();
+
+  /** Some example users, on two separate teams. */
+  private enum TestUser {
+    RED_ONE("scarlet", "red"),
+    RED_TWO("burgundy", "red"),
+    BLUE_ONE("navy", "blue"),
+    BLUE_TWO("sky", "blue");
+
+    private final String userName;
+    private final String teamName;
+
+    TestUser(String userName, String teamName) {
+      this.userName = userName;
+      this.teamName = teamName;
+    }
+
+    public String getUser() {
+      return userName;
+    }
+
+    public String getTeam() {
+      return teamName;
+    }
+  }
+
+  /**
+   * Tests that {@link UpdateTeamScoreFn} {@link org.apache.beam.sdk.transforms.DoFn} outputs
+   * correctly for one team.
+   */
+  @Test
+  public void testScoreUpdatesOneTeam() {
+
+    TestStream<KV<String, GameActionInfo>> createEvents =
+        TestStream.create(KvCoder.of(StringUtf8Coder.of(), AvroCoder.of(GameActionInfo.class)))
+            .advanceWatermarkTo(baseTime)
+            .addElements(
+                event(TestUser.RED_TWO, 99, Duration.standardSeconds(10)),
+                event(TestUser.RED_ONE, 1, Duration.standardSeconds(20)),
+                event(TestUser.RED_ONE, 0, Duration.standardSeconds(30)),
+                event(TestUser.RED_TWO, 100, Duration.standardSeconds(40)),
+                event(TestUser.RED_TWO, 201, Duration.standardSeconds(50)))
+            .advanceWatermarkToInfinity();
+
+    PCollection<KV<String, Integer>> teamScores =
+        p.apply(createEvents).apply(ParDo.of(new UpdateTeamScoreFn(100)));
+
+    String redTeam = TestUser.RED_ONE.getTeam();
+
+    PAssert.that(teamScores)
+        .inWindow(GlobalWindow.INSTANCE)
+        .containsInAnyOrder(KV.of(redTeam, 100), KV.of(redTeam, 200), KV.of(redTeam, 401));
+
+    p.run().waitUntilFinish();
+  }
+
+  /**
+   * Tests that {@link UpdateTeamScoreFn} {@link org.apache.beam.sdk.transforms.DoFn} outputs
+   * correctly for multiple teams.
+   */
+  @Test
+  public void testScoreUpdatesPerTeam() {
+
+    TestStream<KV<String, GameActionInfo>> createEvents =
+        TestStream.create(KvCoder.of(StringUtf8Coder.of(), AvroCoder.of(GameActionInfo.class)))
+            .advanceWatermarkTo(baseTime)
+            .addElements(
+                event(TestUser.RED_ONE, 50, Duration.standardSeconds(10)),
+                event(TestUser.RED_TWO, 50, Duration.standardSeconds(20)),
+                event(TestUser.BLUE_ONE, 70, Duration.standardSeconds(30)),
+                event(TestUser.BLUE_TWO, 80, Duration.standardSeconds(40)),
+                event(TestUser.BLUE_TWO, 50, Duration.standardSeconds(50)))
+            .advanceWatermarkToInfinity();
+
+    PCollection<KV<String, Integer>> teamScores =
+        p.apply(createEvents).apply(ParDo.of(new UpdateTeamScoreFn(100)));
+
+    String redTeam = TestUser.RED_ONE.getTeam();
+    String blueTeam = TestUser.BLUE_ONE.getTeam();
+
+    PAssert.that(teamScores)
+        .inWindow(GlobalWindow.INSTANCE)
+        .containsInAnyOrder(KV.of(redTeam, 100), KV.of(blueTeam, 150), KV.of(blueTeam, 200));
+
+    p.run().waitUntilFinish();
+  }
+
+  /**
+   * Tests that {@link UpdateTeamScoreFn} {@link org.apache.beam.sdk.transforms.DoFn} outputs
+   * correctly per window and per key.
+   */
+  @Test
+  public void testScoreUpdatesPerWindow() {
+
+    TestStream<KV<String, GameActionInfo>> createEvents =
+        TestStream.create(KvCoder.of(StringUtf8Coder.of(), AvroCoder.of(GameActionInfo.class)))
+            .advanceWatermarkTo(baseTime)
+            .addElements(
+                event(TestUser.RED_ONE, 50, Duration.standardMinutes(1)),
+                event(TestUser.RED_TWO, 50, Duration.standardMinutes(2)),
+                event(TestUser.RED_ONE, 50, Duration.standardMinutes(3)),
+                event(TestUser.RED_ONE, 60, Duration.standardMinutes(6)),
+                event(TestUser.RED_TWO, 60, Duration.standardMinutes(7)))
+            .advanceWatermarkToInfinity();
+
+    Duration teamWindowDuration = Duration.standardMinutes(5);
+
+    PCollection<KV<String, Integer>> teamScores =
+        p.apply(createEvents)
+            .apply(Window.<KV<String, GameActionInfo>>into(FixedWindows.of(teamWindowDuration)))
+            .apply(ParDo.of(new UpdateTeamScoreFn(100)));
+
+    String redTeam = TestUser.RED_ONE.getTeam();
+    String blueTeam = TestUser.BLUE_ONE.getTeam();
+
+    IntervalWindow window1 = new IntervalWindow(baseTime, teamWindowDuration);
+    IntervalWindow window2 = new IntervalWindow(window1.end(), teamWindowDuration);
+
+    PAssert.that(teamScores).inWindow(window1).containsInAnyOrder(KV.of(redTeam, 100));
+
+    PAssert.that(teamScores).inWindow(window2).containsInAnyOrder(KV.of(redTeam, 120));
+
+    p.run().waitUntilFinish();
+  }
+
+  private TimestampedValue<KV<String, GameActionInfo>> event(
+      TestUser user, int score, Duration baseTimeOffset) {
+    return TimestampedValue.of(
+        KV.of(
+            user.getTeam(),
+            new GameActionInfo(
+                user.getUser(), user.getTeam(), score, baseTime.plus(baseTimeOffset).getMillis())),
+        baseTime.plus(baseTimeOffset));
+  }
+}

--- a/buildSrc/src/archetype-resources/src/test/java/complete/game/UserScoreTest.java
+++ b/buildSrc/src/archetype-resources/src/test/java/complete/game/UserScoreTest.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.complete.game;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import ${package}.complete.game.UserScore.ExtractAndSumScore;
+import ${package}.complete.game.UserScore.GameActionInfo;
+import ${package}.complete.game.UserScore.ParseEventFn;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.ValidatesRunner;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TypeDescriptors;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests of UserScore. */
+@RunWith(JUnit4.class)
+public class UserScoreTest implements Serializable {
+
+  static final String[] GAME_EVENTS_ARRAY =
+      new String[] {
+        "user0_MagentaKangaroo,MagentaKangaroo,3,1447955630000,2015-11-19 09:53:53.444",
+        "user13_ApricotQuokka,ApricotQuokka,15,1447955630000,2015-11-19 09:53:53.444",
+        "user6_AmberNumbat,AmberNumbat,11,1447955630000,2015-11-19 09:53:53.444",
+        "user7_AlmondWallaby,AlmondWallaby,15,1447955630000,2015-11-19 09:53:53.444",
+        "user7_AndroidGreenKookaburra,AndroidGreenKookaburra,12,1447955630000,2015-11-19 09:53:53.444",
+        "user6_AliceBlueDingo,AliceBlueDingo,4,xxxxxxx,2015-11-19 09:53:53.444",
+        "user7_AndroidGreenKookaburra,AndroidGreenKookaburra,11,1447955630000,2015-11-19 09:53:53.444",
+        "THIS IS A PARSE ERROR,2015-11-19 09:53:53.444",
+        "user19_BisqueBilby,BisqueBilby,6,1447955630000,2015-11-19 09:53:53.444",
+        "user19_BisqueBilby,BisqueBilby,8,1447955630000,2015-11-19 09:53:53.444"
+      };
+
+  static final String[] GAME_EVENTS_ARRAY2 =
+      new String[] {
+        "user6_AliceBlueDingo,AliceBlueDingo,4,xxxxxxx,2015-11-19 09:53:53.444",
+        "THIS IS A PARSE ERROR,2015-11-19 09:53:53.444",
+        "user13_BisqueBilby,BisqueBilby,xxx,1447955630000,2015-11-19 09:53:53.444"
+      };
+
+  static final List<String> GAME_EVENTS = Arrays.asList(GAME_EVENTS_ARRAY);
+  static final List<String> GAME_EVENTS2 = Arrays.asList(GAME_EVENTS_ARRAY2);
+
+  static final List<GameActionInfo> GAME_ACTION_INFO_LIST =
+      Lists.newArrayList(
+          new GameActionInfo("user0_MagentaKangaroo", "MagentaKangaroo", 3, 1447955630000L),
+          new GameActionInfo("user13_ApricotQuokka", "ApricotQuokka", 15, 1447955630000L),
+          new GameActionInfo("user6_AmberNumbat", "AmberNumbat", 11, 1447955630000L),
+          new GameActionInfo("user7_AlmondWallaby", "AlmondWallaby", 15, 1447955630000L),
+          new GameActionInfo(
+              "user7_AndroidGreenKookaburra", "AndroidGreenKookaburra", 12, 1447955630000L),
+          new GameActionInfo(
+              "user7_AndroidGreenKookaburra", "AndroidGreenKookaburra", 11, 1447955630000L),
+          new GameActionInfo("user19_BisqueBilby", "BisqueBilby", 6, 1447955630000L),
+          new GameActionInfo("user19_BisqueBilby", "BisqueBilby", 8, 1447955630000L));
+
+  static final List<KV<String, Integer>> USER_SUMS =
+      Arrays.asList(
+          KV.of("user0_MagentaKangaroo", 3),
+          KV.of("user13_ApricotQuokka", 15),
+          KV.of("user6_AmberNumbat", 11),
+          KV.of("user7_AlmondWallaby", 15),
+          KV.of("user7_AndroidGreenKookaburra", 23),
+          KV.of("user19_BisqueBilby", 14));
+
+  static final List<KV<String, Integer>> TEAM_SUMS =
+      Arrays.asList(
+          KV.of("MagentaKangaroo", 3),
+          KV.of("ApricotQuokka", 15),
+          KV.of("AmberNumbat", 11),
+          KV.of("AlmondWallaby", 15),
+          KV.of("AndroidGreenKookaburra", 23),
+          KV.of("BisqueBilby", 14));
+
+  @Rule public TestPipeline p = TestPipeline.create();
+
+  /** Test the {@link ParseEventFn} {@link org.apache.beam.sdk.transforms.DoFn}. */
+  @Test
+  public void testParseEventFn() throws Exception {
+    PCollection<String> input = p.apply(Create.of(GAME_EVENTS));
+    PCollection<GameActionInfo> output = input.apply(ParDo.of(new ParseEventFn()));
+
+    PAssert.that(output).containsInAnyOrder(GAME_ACTION_INFO_LIST);
+
+    p.run().waitUntilFinish();
+  }
+
+  /** Tests ExtractAndSumScore("user"). */
+  @Test
+  @Category(ValidatesRunner.class)
+  public void testUserScoreSums() throws Exception {
+
+    PCollection<String> input = p.apply(Create.of(GAME_EVENTS));
+
+    PCollection<KV<String, Integer>> output =
+        input
+            .apply(ParDo.of(new ParseEventFn()))
+            // Extract and sum username/score pairs from the event data.
+            .apply("ExtractUserScore", new ExtractAndSumScore("user"));
+
+    // Check the user score sums.
+    PAssert.that(output).containsInAnyOrder(USER_SUMS);
+
+    p.run().waitUntilFinish();
+  }
+
+  /** Tests ExtractAndSumScore("team"). */
+  @Test
+  @Category(ValidatesRunner.class)
+  public void testTeamScoreSums() throws Exception {
+
+    PCollection<String> input = p.apply(Create.of(GAME_EVENTS));
+
+    PCollection<KV<String, Integer>> output =
+        input
+            .apply(ParDo.of(new ParseEventFn()))
+            // Extract and sum teamname/score pairs from the event data.
+            .apply("ExtractTeamScore", new ExtractAndSumScore("team"));
+
+    // Check the team score sums.
+    PAssert.that(output).containsInAnyOrder(TEAM_SUMS);
+
+    p.run().waitUntilFinish();
+  }
+
+  /** Test that bad input data is dropped appropriately. */
+  @Test
+  @Category(ValidatesRunner.class)
+  public void testUserScoresBadInput() throws Exception {
+
+    PCollection<String> input = p.apply(Create.of(GAME_EVENTS2).withCoder(StringUtf8Coder.of()));
+
+    PCollection<KV<String, Integer>> extract =
+        input
+            .apply(ParDo.of(new ParseEventFn()))
+            .apply(
+                MapElements.into(
+                        TypeDescriptors.kvs(TypeDescriptors.strings(), TypeDescriptors.integers()))
+                    .via((GameActionInfo gInfo) -> KV.of(gInfo.getUser(), gInfo.getScore())));
+
+    PAssert.that(extract).empty();
+
+    p.run().waitUntilFinish();
+  }
+}

--- a/buildSrc/src/archetype-resources/src/test/java/subprocess/ExampleEchoPipelineTest.java
+++ b/buildSrc/src/archetype-resources/src/test/java/subprocess/ExampleEchoPipelineTest.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${package}.subprocess;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import ${package}.subprocess.configuration.SubProcessConfiguration;
+import ${package}.subprocess.kernel.SubProcessCommandLineArgs;
+import ${package}.subprocess.kernel.SubProcessCommandLineArgs.Command;
+import ${package}.subprocess.kernel.SubProcessKernel;
+import ${package}.subprocess.utils.CallingSubProcessUtils;
+import org.apache.beam.sdk.extensions.gcp.options.GcsOptions;
+import org.apache.beam.sdk.extensions.gcp.util.GcsUtil;
+import org.apache.beam.sdk.extensions.gcp.util.gcsfs.GcsPath;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * To keep {@link org.apache.beam.examples.subprocess.ExampleEchoPipeline} simple, it is not
+ * factored or testable. This test file should be maintained with a copy of its code for a basic
+ * smoke test.
+ */
+@RunWith(JUnit4.class)
+public class ExampleEchoPipelineTest {
+
+  static final Logger LOG = LoggerFactory.getLogger(ExampleEchoPipelineTest.class);
+
+  @Rule public TestPipeline p = TestPipeline.create().enableAbandonedNodeEnforcement(false);
+
+  @Test
+  public void testExampleEchoPipeline() throws Exception {
+
+    // Create two Bash files as tests for the binary files
+
+    Path fileA = Files.createTempFile("test-Echo", ".sh");
+    Path fileB = Files.createTempFile("test-EchoAgain", ".sh");
+
+    Path workerTempFiles = Files.createTempDirectory("test-Echoo");
+
+    try (SeekableByteChannel channel =
+        FileChannel.open(fileA, StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
+      channel.write(ByteBuffer.wrap(getTestShellEcho().getBytes(UTF_8)));
+    }
+
+    try (SeekableByteChannel channel =
+        FileChannel.open(fileB, StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
+      channel.write(ByteBuffer.wrap(getTestShellEchoAgain().getBytes(UTF_8)));
+    }
+
+    // Read in the options for the pipeline
+    SubProcessPipelineOptions options = PipelineOptionsFactory.as(SubProcessPipelineOptions.class);
+
+    options.setConcurrency(2);
+    options.setSourcePath(fileA.getParent().toString());
+    options.setWorkerPath(workerTempFiles.toAbsolutePath().toString());
+
+    p.getOptions().as(GcsOptions.class).setGcsUtil(buildMockGcsUtil());
+
+    // Setup the Configuration option used with all transforms
+    SubProcessConfiguration configuration = options.getSubProcessConfiguration();
+
+    // Create some sample data to be fed to our c++ Echo library
+    List<KV<String, String>> sampleData = new ArrayList<>();
+
+    for (int i = 0; i < 100; i++) {
+      String str = String.valueOf(i);
+      sampleData.add(KV.of(str, str));
+    }
+
+    // Define the pipeline which is two transforms echoing the inputs out to Logs
+    // For this use case we will make use of two shell files instead of the binary to make
+    // testing easier
+    PCollection<KV<String, String>> output =
+        p.apply(Create.of(sampleData))
+            .apply(
+                "Echo inputs round 1",
+                ParDo.of(new EchoInputDoFn(configuration, fileA.getFileName().toString())))
+            .apply(
+                "Echo inputs round 2",
+                ParDo.of(new EchoInputDoFn(configuration, fileB.getFileName().toString())));
+
+    PAssert.that(output).containsInAnyOrder(sampleData);
+
+    p.run();
+  }
+
+  /** Simple DoFn that echos the element, used as an example of running a C++ library. */
+  @SuppressWarnings("serial")
+  private static class EchoInputDoFn extends DoFn<KV<String, String>, KV<String, String>> {
+
+    static final Logger LOG = LoggerFactory.getLogger(EchoInputDoFn.class);
+
+    private SubProcessConfiguration configuration;
+    private String binaryName;
+
+    public EchoInputDoFn(SubProcessConfiguration configuration, String binary) {
+      // Pass in configuration information the name of the filename of the sub-process and the level
+      // of concurrency
+      this.configuration = configuration;
+      this.binaryName = binary;
+    }
+
+    @Setup
+    public void setUp() throws Exception {
+      CallingSubProcessUtils.setUp(configuration, binaryName);
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext c) throws Exception {
+      try {
+        // Our Library takes a single command in position 0 which it will echo back in the result
+        SubProcessCommandLineArgs commands = new SubProcessCommandLineArgs();
+        Command command = new Command(0, String.valueOf(c.element().getValue()));
+        commands.putCommand(command);
+
+        // The ProcessingKernel deals with the execution of the process
+        SubProcessKernel kernel = new SubProcessKernel(configuration, binaryName);
+
+        // Run the command and work through the results
+        List<String> results = kernel.exec(commands);
+        for (String s : results) {
+          c.output(KV.of(c.element().getKey(), s));
+        }
+      } catch (Exception ex) {
+        LOG.error("Error processing element ", ex);
+        throw ex;
+      }
+    }
+  }
+
+  private static String getTestShellEcho() {
+    return "#!/bin/sh\n" + "filename=$1;\n" + "echo $2 >> $filename;";
+  }
+
+  private static String getTestShellEchoAgain() {
+    return "#!/bin/sh\n" + "filename=$1;\n" + "echo $2 >> $filename;";
+  }
+
+  private GcsUtil buildMockGcsUtil() throws IOException {
+    GcsUtil mockGcsUtil = Mockito.mock(GcsUtil.class);
+
+    // Any request to open gets a new bogus channel
+    Mockito.when(mockGcsUtil.open(Mockito.any(GcsPath.class)))
+        .then(
+            new Answer<SeekableByteChannel>() {
+
+              @Override
+              public SeekableByteChannel answer(InvocationOnMock invocation) throws Throwable {
+                return FileChannel.open(
+                    Files.createTempFile("channel-", ".tmp"),
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.DELETE_ON_CLOSE);
+              }
+            });
+
+    // Any request for expansion returns a list containing the original GcsPath
+    // This is required to pass validation that occurs in TextIO during apply()
+    Mockito.when(mockGcsUtil.expand(Mockito.any(GcsPath.class)))
+        .then(
+            new Answer<List<GcsPath>>() {
+
+              @Override
+              public List<GcsPath> answer(InvocationOnMock invocation) throws Throwable {
+                return ImmutableList.of((GcsPath) invocation.getArguments()[0]);
+              }
+            });
+
+    return mockGcsUtil;
+  }
+}


### PR DESCRIPTION
This PR is pretty long, because I committed what the result is after running the gradle task and generating the jar files. When I grab from 'org.apache.beam:beam-sdks-java-maven-archetypes-examples:2.21.0' it pulls a lot of jar files and puts it into the build/lib (this is where people Google told me it should go, please leave your thoughts) and I filter it to only extract from the one I know we want. However, I'm not sure all these jar files are needed and if there's a better way. After it extracts it puts the result in archetype-resources under src/ but I noticed that the files in here are not recognized by Intellij as modules. Additionally, the extracted files have some problems because they are missing values for the variables like ${groupId), ${artifactId}, etc.. that are normally set when using Maven's generate:archetype. I wasn't able to figure out how to set these when only using Gradle. 